### PR TITLE
Use explicit spawn context for WorkerProc

### DIFF
--- a/trio_parallel/_tests/test_worker_processes.py
+++ b/trio_parallel/_tests/test_worker_processes.py
@@ -114,7 +114,7 @@ def _null_func():  # pragma: no cover
 async def test_run_in_worker_process_fail_to_spawn(monkeypatch):
     from .. import _worker_processes
     # Test the unlikely but possible case where trying to spawn a worker fails
-    def bad_start():
+    def bad_start(*a, **kw):
         raise RuntimeError("the engines canna take it captain")
 
     monkeypatch.setattr(_worker_processes, "WorkerProc", bad_start)

--- a/trio_parallel/_worker_processes.py
+++ b/trio_parallel/_worker_processes.py
@@ -3,7 +3,7 @@ import struct
 import trio
 from collections import deque
 from itertools import count
-from multiprocessing import Pipe, Process
+from multiprocessing import get_context
 from multiprocessing.reduction import ForkingPickler
 
 _limiter_local = trio.lowlevel.RunVar("proc_limiter")
@@ -90,10 +90,10 @@ PROC_CACHE = ProcCache()
 
 
 class WorkerProc:
-    def __init__(self):
-        child_recv_pipe, self._send_pipe = Pipe(duplex=False)
-        self._recv_pipe, child_send_pipe = Pipe(duplex=False)
-        self._proc = Process(
+    def __init__(self, mp_context=get_context("spawn")):
+        child_recv_pipe, self._send_pipe = mp_context.Pipe(duplex=False)
+        self._recv_pipe, child_send_pipe = mp_context.Pipe(duplex=False)
+        self._proc = mp_context.Process(
             target=self._work,
             args=(child_recv_pipe, child_send_pipe),
             name=f"Trio worker process {next(_proc_counter)}",


### PR DESCRIPTION
Closes #4. Future plans may allow for configurable worker startup methods.