### PR TITLE
removal of child monitor task in WorkerProc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   Windows:
     name: 'Windows (${{ matrix.python }}, ${{ matrix.arch }}${{ matrix.extra_name }})'
-    timeout-minutes: 20
+    timeout-minutes: 5
     runs-on: 'windows-latest'
     strategy:
       fail-fast: false
@@ -37,7 +37,7 @@ jobs:
 
   Linux:
     name: 'Linux (${{ matrix.python }}${{ matrix.extra_name }})'
-    timeout-minutes: 10
+    timeout-minutes: 5
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
@@ -82,7 +82,7 @@ jobs:
 
   macOS:
     name: 'macOS (${{ matrix.python }})'
-    timeout-minutes: 10
+    timeout-minutes: 5
     runs-on: 'macos-latest'
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   Windows:
     name: 'Windows (${{ matrix.python }}, ${{ matrix.arch }}${{ matrix.extra_name }})'
-    timeout-minutes: 5
+    timeout-minutes: 20
     runs-on: 'windows-latest'
     strategy:
       fail-fast: false
@@ -44,7 +44,7 @@ jobs:
 
   Linux:
     name: 'Linux (${{ matrix.python }}${{ matrix.extra_name }})'
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
@@ -96,7 +96,7 @@ jobs:
 
   macOS:
     name: 'macOS (${{ matrix.python }})'
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: 'macos-latest'
     strategy:
       fail-fast: false

--- a/trio_parallel/_tests/test_worker_processes.py
+++ b/trio_parallel/_tests/test_worker_processes.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import os
+import platform
 
 import pytest
 import trio

--- a/trio_parallel/_tests/test_worker_processes.py
+++ b/trio_parallel/_tests/test_worker_processes.py
@@ -250,8 +250,12 @@ async def test_exhaustively_cancel_run_sync():
     proc = WorkerProc()
     with trio.fail_after(1):
         with trio.move_on_after(0):
+            print("attempting run_sync")
             await proc.run_sync(_never_halts, ev)
+            print("should not see this")
+        print("run_sync done, proc.wait now")
         await proc.wait()
+        print("proc.wait done")
 
     # cancel at result recv is tested elsewhere
 

--- a/trio_parallel/_tests/test_worker_processes.py
+++ b/trio_parallel/_tests/test_worker_processes.py
@@ -203,10 +203,11 @@ async def test_to_process_run_sync_raises_on_kill():
     await to_process_run_sync(_null_func)
     proc = PROC_CACHE._cache[0]
     with pytest.raises(BrokenWorkerError):
-        async with trio.open_nursery() as nursery:
-            nursery.start_soon(child)
-            await trio.to_thread.run_sync(ev.wait)
-            proc.kill()
+        with trio.move_on_after(10):
+            async with trio.open_nursery() as nursery:
+                nursery.start_soon(child)
+                await trio.to_thread.run_sync(ev.wait)
+                proc.kill()
 
 
 async def test_spawn_worker_in_thread_and_prune_cache():

--- a/trio_parallel/_tests/test_worker_processes.py
+++ b/trio_parallel/_tests/test_worker_processes.py
@@ -203,7 +203,7 @@ async def test_to_process_run_sync_raises_on_kill():
     await to_process_run_sync(_null_func)
     proc = PROC_CACHE._cache[0]
     with pytest.raises(BrokenWorkerError):
-        with trio.move_on_after(10):
+        with trio.fail_after(1):
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(child)
                 try:
@@ -266,5 +266,6 @@ async def test_racing_timeout():
     await proc.run_sync(_shorten_timeout)
     with trio.fail_after(1):
         await proc.wait()
-        with pytest.raises(trio.BrokenResourceError):
+        with pytest.raises(BrokenPipeError):
+        # with pytest.raises(trio.BrokenResourceError):
             await proc.run_sync(_null_func)

--- a/trio_parallel/_tests/test_worker_processes.py
+++ b/trio_parallel/_tests/test_worker_processes.py
@@ -203,7 +203,7 @@ async def test_to_process_run_sync_raises_on_kill():
     await to_process_run_sync(_null_func)
     proc = PROC_CACHE._cache[0]
     with pytest.raises(BrokenWorkerError):
-        with trio.fail_after(1):
+        with trio.move_on_after(10):
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(child)
                 try:
@@ -266,6 +266,5 @@ async def test_racing_timeout():
     await proc.run_sync(_shorten_timeout)
     with trio.fail_after(1):
         await proc.wait()
-        with pytest.raises(BrokenPipeError):
-        # with pytest.raises(trio.BrokenResourceError):
+        with pytest.raises(trio.BrokenResourceError):
             await proc.run_sync(_null_func)

--- a/trio_parallel/_tests/test_worker_processes.py
+++ b/trio_parallel/_tests/test_worker_processes.py
@@ -1,6 +1,5 @@
 import multiprocessing
 import os
-import platform
 
 import pytest
 import trio

--- a/trio_parallel/_tests/test_worker_processes.py
+++ b/trio_parallel/_tests/test_worker_processes.py
@@ -250,12 +250,8 @@ async def test_exhaustively_cancel_run_sync():
     proc = WorkerProc()
     with trio.fail_after(1):
         with trio.move_on_after(0):
-            print("attempting run_sync")
             await proc.run_sync(_never_halts, ev)
-            print("should not see this")
-        print("run_sync done, proc.wait now")
         await proc.wait()
-        print("proc.wait done")
 
     # cancel at result recv is tested elsewhere
 
@@ -270,5 +266,5 @@ async def test_racing_timeout():
     await proc.run_sync(_shorten_timeout)
     with trio.fail_after(1):
         await proc.wait()
-    with pytest.raises(trio.BrokenResourceError):
-        await proc.run_sync(_null_func)
+        with pytest.raises(trio.BrokenResourceError):
+            await proc.run_sync(_null_func)

--- a/trio_parallel/_tests/test_worker_processes.py
+++ b/trio_parallel/_tests/test_worker_processes.py
@@ -207,7 +207,7 @@ async def test_to_process_run_sync_raises_on_kill():
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(child)
                 await trio.to_thread.run_sync(ev.wait)
-                proc.kill()
+                # proc.kill()
 
 
 async def test_spawn_worker_in_thread_and_prune_cache():

--- a/trio_parallel/_tests/test_worker_processes.py
+++ b/trio_parallel/_tests/test_worker_processes.py
@@ -198,7 +198,7 @@ async def test_to_process_run_sync_raises_on_kill():
     ev = m.Event()
 
     async def child():
-        await to_process_run_sync(_never_halts, ev)
+        await to_process_run_sync(_never_halts, ev, cancellable=True)
 
     await to_process_run_sync(_null_func)
     proc = PROC_CACHE._cache[0]
@@ -206,8 +206,12 @@ async def test_to_process_run_sync_raises_on_kill():
         with trio.move_on_after(10):
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(child)
-                await trio.to_thread.run_sync(ev.wait)
-                # proc.kill()
+                try:
+                    await trio.to_thread.run_sync(ev.wait, cancellable=True)
+                finally:
+                    # if something goes wrong, free the thread
+                    ev.set()
+                proc.kill()
 
 
 async def test_spawn_worker_in_thread_and_prune_cache():

--- a/trio_parallel/_worker_processes.py
+++ b/trio_parallel/_worker_processes.py
@@ -187,16 +187,16 @@ class WorkerProcBase:
         except AttributeError:
             self._proc.terminate()
 
-    def _rehabilitate_pipes(self):
+    def _rehabilitate_pipes(self):  # pragma: no cover
         pass
 
-    async def _recv(self):
+    async def _recv(self):  # pragma: no cover
         pass
 
-    async def _send(self, buf):
+    async def _send(self, buf):  # pragma: no cover
         pass
 
-    async def wait(self):
+    async def wait(self):  # pragma: no cover
         pass
 
 

--- a/trio_parallel/_worker_processes.py
+++ b/trio_parallel/_worker_processes.py
@@ -303,8 +303,6 @@ class PypyWorkerProc(WorkerProcBase):
         raise BrokenWorkerError(f"{self._proc} died unexpectedly")
 
 
-
-
 if os.name == "nt":
 
     class WorkerProc(WindowsWorkerProc):

--- a/trio_parallel/_worker_processes.py
+++ b/trio_parallel/_worker_processes.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import struct
 import trio
 from collections import deque
@@ -83,7 +84,7 @@ class ProcCache:
 PROC_CACHE = ProcCache()
 
 
-class WorkerProc:
+class WorkerProcBase:
     def __init__(self, mp_context=get_context("spawn")):
         child_recv_pipe, self._send_pipe = mp_context.Pipe(duplex=False)
         self._recv_pipe, child_send_pipe = mp_context.Pipe(duplex=False)
@@ -131,14 +132,11 @@ class WorkerProc:
             send_pipe.close()
 
     async def run_sync(self, sync_fn, *args):
-        # self._rehabilitate_pipes()
+        self._rehabilitate_pipes()
         try:
-            await trio.to_thread.run_sync(self._send_pipe.send, (sync_fn, args), cancellable=True)
-            result = await trio.to_thread.run_sync(self._recv_pipe.recv, cancellable=True)
-            # await self._send(ForkingPickler.dumps((sync_fn, args)))
-            # result = ForkingPickler.loads(await self._recv())
-        except EOFError:
-        # except trio.EndOfChannel:
+            await self._send(ForkingPickler.dumps((sync_fn, args)))
+            result = ForkingPickler.loads(await self._recv())
+        except trio.EndOfChannel:
             # Likely the worker died while we were waiting on a pipe
             self.kill()  # Just make sure
             raise BrokenWorkerError(f"{self._proc} died unexpectedly")
@@ -161,91 +159,140 @@ class WorkerProc:
         except AttributeError:
             self._proc.terminate()
 
-    if os.name == "nt":
+    def _rehabilitate_pipes(self):
+        pass
 
-        async def wait(self):
-            await trio.lowlevel.WaitForSingleObject(self._proc.sentinel)
+    async def _recv(self):
+        pass
 
-        def _rehabilitate_pipes(self):
-            # These must be created in an async context, so defer so
-            # that this object can be instantiated in e.g. a thread
-            if not hasattr(self, "_send_chan"):
-                from ._windows_pipes import PipeSendChannel, PipeReceiveChannel
-                self._send_chan = PipeSendChannel(self._send_pipe.fileno())
-                self._recv_chan = PipeReceiveChannel(self._recv_pipe.fileno())
-                self._send = self._send_chan.send
-                self._recv = self._recv_chan.receive
+    async def _send(self, buf):
+        pass
 
-        def __del__(self):
-            # Avoid __del__ errors on cleanup: GH#174, GH#1767
-            # multiprocessing will close them for us
-            if hasattr(self, "_send_chan"):
-                self._send_chan._handle_holder.handle = -1
-                self._recv_chan._handle_holder.handle = -1
+    async def wait(self):
+        pass
 
-    else:
 
-        async def wait(self):
-            await trio.lowlevel.wait_readable(self._proc.sentinel)
+class WindowsWorkerProc(WorkerProcBase):
+    async def wait(self):
+        await trio.lowlevel.WaitForSingleObject(self._proc.sentinel)
 
-        def _rehabilitate_pipes(self):
-            # These must be created in an async context, so defer so
-            # that this object can be instantiated in e.g. a thread
-            if not hasattr(self, "_send_stream"):
-                self._send_stream = trio.lowlevel.FdStream(self._send_pipe.fileno())
-                self._recv_stream = trio.lowlevel.FdStream(self._recv_pipe.fileno())
+    def _rehabilitate_pipes(self):
+        # These must be created in an async context, so defer so
+        # that this object can be instantiated in e.g. a thread
+        if not hasattr(self, "_send_chan"):
+            from ._windows_pipes import PipeSendChannel, PipeReceiveChannel
 
-        async def _recv(self):
-            buf = await self._recv_exactly(4)
-            (size,) = struct.unpack("!i", buf)
-            if size == -1:
-                buf = await self._recv_exactly(8)
-                (size,) = struct.unpack("!Q", buf)
-            return await self._recv_exactly(size)
+            self._send_chan = PipeSendChannel(self._send_pipe.fileno())
+            self._recv_chan = PipeReceiveChannel(self._recv_pipe.fileno())
+            self._send = self._send_chan.send
+            self._recv = self._recv_chan.receive
 
-        async def _recv_exactly(self, size):
-            result_bytes = bytearray()
-            while size:
-                partial_result = await self._recv_stream.receive_some(size)
-                num_recvd = len(partial_result)
-                if not num_recvd:
-                    raise trio.EndOfChannel("got end of file during message")
-                result_bytes.extend(partial_result)
-                if num_recvd > size:  # pragma: no cover
-                    raise RuntimeError("Oversized response")
-                else:
-                    size -= num_recvd
-            return result_bytes
+    def __del__(self):
+        # Avoid __del__ errors on cleanup: GH#174, GH#1767
+        # multiprocessing will close them for us
+        if hasattr(self, "_send_chan"):
+            self._send_chan._handle_holder.handle = -1
+            self._recv_chan._handle_holder.handle = -1
 
-        async def _send(self, buf):
-            n = len(buf)
-            if n > 0x7FFFFFFF:
-                pre_header = struct.pack("!i", -1)
-                header = struct.pack("!Q", n)
-                await self._send_stream.send_all(pre_header)
+
+class PosixWorkerProc(WorkerProcBase):
+    async def wait(self):
+        await trio.lowlevel.wait_readable(self._proc.sentinel)
+
+    def _rehabilitate_pipes(self):
+        # These must be created in an async context, so defer so
+        # that this object can be instantiated in e.g. a thread
+        if not hasattr(self, "_send_stream"):
+            self._send_stream = trio.lowlevel.FdStream(self._send_pipe.fileno())
+            self._recv_stream = trio.lowlevel.FdStream(self._recv_pipe.fileno())
+
+    async def _recv(self):
+        buf = await self._recv_exactly(4)
+        (size,) = struct.unpack("!i", buf)
+        if size == -1:
+            buf = await self._recv_exactly(8)
+            (size,) = struct.unpack("!Q", buf)
+        return await self._recv_exactly(size)
+
+    async def _recv_exactly(self, size):
+        result_bytes = bytearray()
+        while size:
+            partial_result = await self._recv_stream.receive_some(size)
+            num_recvd = len(partial_result)
+            if not num_recvd:
+                raise trio.EndOfChannel("got end of file during message")
+            result_bytes.extend(partial_result)
+            if num_recvd > size:  # pragma: no cover
+                raise RuntimeError("Oversized response")
+            else:
+                size -= num_recvd
+        return result_bytes
+
+    async def _send(self, buf):
+        n = len(buf)
+        if n > 0x7FFFFFFF:
+            pre_header = struct.pack("!i", -1)
+            header = struct.pack("!Q", n)
+            await self._send_stream.send_all(pre_header)
+            await self._send_stream.send_all(header)
+            await self._send_stream.send_all(buf)
+        else:
+            # For wire compatibility with 3.7 and lower
+            header = struct.pack("!i", n)
+            if n > 16384:
+                # The payload is large so Nagle's algorithm won't be triggered
+                # and we'd better avoid the cost of concatenation.
                 await self._send_stream.send_all(header)
                 await self._send_stream.send_all(buf)
             else:
-                # For wire compatibility with 3.7 and lower
-                header = struct.pack("!i", n)
-                if n > 16384:
-                    # The payload is large so Nagle's algorithm won't be triggered
-                    # and we'd better avoid the cost of concatenation.
-                    await self._send_stream.send_all(header)
-                    await self._send_stream.send_all(buf)
-                else:
-                    # Issue #20540: concatenate before sending, to avoid delays due
-                    # to Nagle's algorithm on a TCP socket.
-                    # Also note we want to avoid sending a 0-length buffer separately,
-                    # to avoid "broken pipe" errors if the other end closed the pipe.
-                    await self._send_stream.send_all(header + buf)
+                # Issue #20540: concatenate before sending, to avoid delays due
+                # to Nagle's algorithm on a TCP socket.
+                # Also note we want to avoid sending a 0-length buffer separately,
+                # to avoid "broken pipe" errors if the other end closed the pipe.
+                await self._send_stream.send_all(header + buf)
 
-        def __del__(self):
-            # Avoid __del__ errors on cleanup: GH#174, GH#1767
-            # multiprocessing will close them for us
-            if hasattr(self, "_send_stream"):
-                self._send_stream._fd_holder.fd = -1
-                self._recv_stream._fd_holder.fd = -1
+    def __del__(self):
+        # Avoid __del__ errors on cleanup: GH#174, GH#1767
+        # multiprocessing will close them for us
+        if hasattr(self, "_send_stream"):
+            self._send_stream._fd_holder.fd = -1
+            self._recv_stream._fd_holder.fd = -1
+
+
+class PypyWorkerProc(WorkerProcBase):
+    async def run_sync(self, sync_fn, *args):
+        async with trio.open_nursery() as nursery:
+            nursery.start_soon(self.child_monitor)
+            result = await super().run_sync(sync_fn, *args)
+            nursery.cancel_scope.cancel()
+        return result
+
+    async def child_monitor(self):
+        # If this worker dies, raise a catchable error...
+        await self.wait()
+        # but not if another error or cancel is incoming, those take priority!
+        await trio.lowlevel.checkpoint_if_cancelled()
+        raise BrokenWorkerError(f"{self._proc} died unexpectedly")
+
+
+
+
+if os.name == "nt":
+
+    class WorkerProc(WindowsWorkerProc):
+        pass
+
+
+elif platform.python_implementation == "PyPy":
+
+    class WorkerProc(PypyWorkerProc, PosixWorkerProc):
+        pass
+
+
+else:
+
+    class WorkerProc(PosixWorkerProc):
+        pass
 
 
 async def to_process_run_sync(sync_fn, *args, cancellable=False, limiter=None):
@@ -300,8 +347,7 @@ async def to_process_run_sync(sync_fn, *args, cancellable=False, limiter=None):
             try:
                 with trio.CancelScope(shield=not cancellable):
                     return await proc.run_sync(sync_fn, *args)
-            except BrokenPipeError:
-            # except trio.BrokenResourceError:
+            except trio.BrokenResourceError:
                 # Rare case where proc timed out even though it was still alive
                 # as we popped it. Just retry.
                 pass

--- a/trio_parallel/_worker_processes.py
+++ b/trio_parallel/_worker_processes.py
@@ -309,7 +309,7 @@ if os.name == "nt":
         pass
 
 
-elif platform.python_implementation == "PyPy":
+elif platform.python_implementation() == "PyPy":
 
     class WorkerProc(PypyWorkerProc, PosixWorkerProc):
         pass


### PR DESCRIPTION
Some platforms needed an extra task to watch the child's file descriptor for certain cases, otherwise segfaults would lead to hangs instead of errors.  But I never found out why so this PR plays with the CI to try to get a handle on that weirdness.