### PR TITLE
Restore Barrier synchronization strategy

### DIFF
--- a/trio_parallel/_tests/test_worker_processes.py
+++ b/trio_parallel/_tests/test_worker_processes.py
@@ -8,7 +8,8 @@ from .._worker_processes import (
     PROC_CACHE,
     to_process_run_sync,
     current_default_process_limiter,
-    BrokenWorkerError, WorkerProc,
+    BrokenWorkerError,
+    WorkerProc,
 )
 from trio.testing import wait_all_tasks_blocked
 
@@ -113,6 +114,7 @@ def _null_func():  # pragma: no cover
 
 async def test_run_in_worker_process_fail_to_spawn(monkeypatch):
     from .. import _worker_processes
+
     # Test the unlikely but possible case where trying to spawn a worker fails
     def bad_start(*a, **kw):
         raise RuntimeError("the engines canna take it captain")

--- a/trio_parallel/_tests/test_worker_processes.py
+++ b/trio_parallel/_tests/test_worker_processes.py
@@ -249,17 +249,3 @@ async def test_exhaustively_cancel_run_sync():
         await proc.wait()
 
     # cancel at result recv is tested elsewhere
-
-
-def _shorten_timeout():  # pragma: no cover
-    from .. import _worker_processes
-    _worker_processes.IDLE_TIMEOUT = 0
-
-
-async def test_racing_timeout():
-    proc = WorkerProc()
-    await proc.run_sync(_shorten_timeout)
-    with trio.fail_after(1):
-        await proc.wait()
-    with pytest.raises(trio.BrokenResourceError):
-        await proc.run_sync(_null_func)

--- a/trio_parallel/_windows_cffi.py
+++ b/trio_parallel/_windows_cffi.py
@@ -86,7 +86,7 @@ class PipeModes(enum.IntFlag):
 ################################################################
 
 
-def _handle(obj):
+def _handle(obj):  # pragma: no cover
     # For now, represent handles as either cffi HANDLEs or as ints.  If you
     # try to pass in a file descriptor instead, it's not going to work
     # out. (For that msvcrt.get_osfhandle does the trick, but I don't know if
@@ -99,22 +99,13 @@ def _handle(obj):
         return obj
 
 
-def raise_winerror(winerror=None, *, filename=None, filename2=None):
+def raise_winerror(winerror=None, *, filename=None, filename2=None):  # pragma: no cover
     if winerror is None:
         winerror, msg = ffi.getwinerror()
     else:
         _, msg = ffi.getwinerror(winerror)
     # https://docs.python.org/3/library/exceptions.html#OSError
     raise OSError(0, msg, filename, winerror, filename2)
-
-
-def get_pipe_state(handle):
-    lpState = ffi.new("LPDWORD")
-    if not kernel32.GetNamedPipeHandleStateA(
-        _handle(handle), lpState, ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL, 0
-    ):
-        raise_winerror()  # pragma: no cover
-    return lpState[0]
 
 
 def peek_pipe_message_left(handle):

--- a/trio_parallel/_windows_cffi.py
+++ b/trio_parallel/_windows_cffi.py
@@ -30,7 +30,9 @@ BOOL GetNamedPipeHandleStateA(
 
 # cribbed from pywincffi
 # programmatically strips out those annotations MSDN likes, like _In_
-REGEX_SAL_ANNOTATION = re.compile(r"\b(_In_|_Inout_|_Out_|_Outptr_|_Reserved_)(opt_)?\b")
+REGEX_SAL_ANNOTATION = re.compile(
+    r"\b(_In_|_Inout_|_Out_|_Outptr_|_Reserved_)(opt_)?\b"
+)
 LIB = REGEX_SAL_ANNOTATION.sub(" ", LIB)
 
 # Other fixups:
@@ -117,6 +119,8 @@ def get_pipe_state(handle):
 
 def peek_pipe_message_left(handle):
     left = ffi.new("LPDWORD")
-    if not kernel32.PeekNamedPipe(_handle(handle), ffi.NULL, 0, ffi.NULL, ffi.NULL, left):
+    if not kernel32.PeekNamedPipe(
+        _handle(handle), ffi.NULL, 0, ffi.NULL, ffi.NULL, left
+    ):
         raise_winerror()  # pragma: no cover
     return left[0]

--- a/trio_parallel/_windows_pipes.py
+++ b/trio_parallel/_windows_pipes.py
@@ -22,7 +22,7 @@ class PipeSendChannel(SendChannel[bytes]):
         # Works just fine if the pipe is message-oriented
         await self._pss.send_all(value)
 
-    async def aclose(self):
+    async def aclose(self):  # pragma: no cover
         await self._handle_holder.aclose()
 
 
@@ -55,14 +55,14 @@ class PipeReceiveChannel(ReceiveChannel[bytes]):
                 return buffer
 
     async def _receive_some_into(self, buffer) -> bytes:
-        if self._handle_holder.closed:
+        if self._handle_holder.closed:  # pragma: no cover
             raise trio.ClosedResourceError("this pipe is already closed")
         try:
             return await trio.lowlevel.readinto_overlapped(
                 self._handle_holder.handle, buffer
             )
         except BrokenPipeError:
-            if self._handle_holder.closed:
+            if self._handle_holder.closed:  # pragma: no cover
                 raise trio.ClosedResourceError(
                     "another task closed this pipe"
                 ) from None
@@ -75,5 +75,5 @@ class PipeReceiveChannel(ReceiveChannel[bytes]):
             await trio.lowlevel.checkpoint()
             raise trio.EndOfChannel
 
-    async def aclose(self):
+    async def aclose(self):  # pragma: no cover
         await self._handle_holder.aclose()

--- a/trio_parallel/_worker_processes.py
+++ b/trio_parallel/_worker_processes.py
@@ -237,7 +237,7 @@ class WorkerProc:
         async def _recv(self):
             buf = await self._recv_exactly(4)
             (size,) = struct.unpack("!i", buf)
-            if size == -1:
+            if size == -1:  # pragma: no cover # can't go this big on CI
                 buf = await self._recv_exactly(8)
                 (size,) = struct.unpack("!Q", buf)
             return await self._recv_exactly(size)
@@ -258,7 +258,7 @@ class WorkerProc:
 
         async def _send(self, buf):
             n = len(buf)
-            if n > 0x7FFFFFFF:
+            if n > 0x7FFFFFFF:  # pragma: no cover # can't go this big on CI
                 pre_header = struct.pack("!i", -1)
                 header = struct.pack("!Q", n)
                 await self._send_stream.send_all(pre_header)

--- a/trio_parallel/_worker_processes.py
+++ b/trio_parallel/_worker_processes.py
@@ -209,6 +209,7 @@ class WorkerProc:
             # that this object can be instantiated in e.g. a thread
             if not hasattr(self, "_send_chan"):
                 from ._windows_pipes import PipeSendChannel, PipeReceiveChannel
+
                 self._send_chan = PipeSendChannel(self._send_pipe.fileno())
                 self._recv_chan = PipeReceiveChannel(self._recv_pipe.fileno())
                 self._send = self._send_chan.send

--- a/trio_parallel/_worker_processes.py
+++ b/trio_parallel/_worker_processes.py
@@ -1,5 +1,7 @@
 import os
 import struct
+from threading import BrokenBarrierError
+
 import trio
 from collections import deque
 from itertools import count
@@ -70,10 +72,16 @@ class ProcCache:
         self._cache.append(proc)
 
     def pop(self):
-        """Get live worker process or raise IndexError"""
+        # Get live, WOKEN worker process or raise IndexError
         while True:
             proc = self._cache.pop()
-            if proc.is_alive():
+            try:
+                proc.wake_up(0)
+            except BrokenWorkerError:
+                # proc must have died in the cache, just try again
+                proc.kill()
+                continue
+            else:
                 return proc
 
     def __len__(self):
@@ -85,24 +93,27 @@ PROC_CACHE = ProcCache()
 
 class WorkerProc:
     def __init__(self, mp_context=get_context("spawn")):
+        # it is almost possible to synchronize on the pipe alone
+        self._barrier = mp_context.Barrier(2)
         child_recv_pipe, self._send_pipe = mp_context.Pipe(duplex=False)
         self._recv_pipe, child_send_pipe = mp_context.Pipe(duplex=False)
         self._proc = mp_context.Process(
             target=self._work,
-            args=(child_recv_pipe, child_send_pipe),
-            name=f"Trio worker process {next(_proc_counter)}",
+            args=(self._barrier, child_recv_pipe, child_send_pipe),
+            name=f"trio-parallel worker process {next(_proc_counter)}",
             daemon=True,
         )
         # The following initialization methods may take a long time
         self._proc.start()
+        self.wake_up()
 
     @staticmethod
-    def _work(recv_pipe, send_pipe):  # pragma: no cover
+    def _work(barrier, recv_pipe, send_pipe):  # pragma: no cover
 
         import inspect
         import outcome
 
-        def worker_fn():
+        def coroutine_checker(fn, args):
             ret = fn(*args)
             if inspect.iscoroutine(ret):
                 # Manually close coroutine to avoid RuntimeWarnings
@@ -114,24 +125,29 @@ class WorkerProc:
 
             return ret
 
-        try:
-            while recv_pipe.poll(timeout=IDLE_TIMEOUT):
-                fn, args = recv_pipe.recv()
-                result = outcome.capture(worker_fn)
-                # Unlike the thread cache, it's impossible to deliver the
-                # result from the worker process. So shove it onto the queue
-                # and hope the receiver delivers the result and marks us idle
-                send_pipe.send(result)
+        while True:
+            try:
+                # Return value is party #, not whether awoken within timeout
+                barrier.wait(timeout=IDLE_TIMEOUT)
+            except BrokenBarrierError:
+                # Timeout waiting for job, so we can exit.
+                return
+            # We got a job, and we are "woken"
+            fn, args = recv_pipe.recv()
+            result = outcome.capture(coroutine_checker, fn, args)
+            # Tell the cache that we're done and available for a job
+            # Unlike the thread cache, it's impossible to deliver the
+            # result from the worker process. So shove it onto the queue
+            # and hope the receiver delivers the result and marks us idle
+            send_pipe.send(result)
 
-                del fn
-                del args
-                del result
-        finally:
-            recv_pipe.close()
-            send_pipe.close()
+            del fn
+            del args
+            del result
 
     async def run_sync(self, sync_fn, *args):
         # Neither this nor the child process should be waiting at this point
+        assert not self._barrier.n_waiting, "Must first wake_up() the WorkerProc"
         self._rehabilitate_pipes()
         async with trio.open_nursery() as nursery:
             # Monitor needed for pypy and other platforms that don't
@@ -159,16 +175,25 @@ class WorkerProc:
     async def _child_monitor(self):
         # If this worker dies, raise a catchable error...
         await self.wait()
-        # but not if another error or cancel is incoming, those take priority!
-        await trio.lowlevel.checkpoint_if_cancelled()
         raise BrokenWorkerError(f"{self._proc} died unexpectedly")
 
     def is_alive(self):
-        # Even if the proc is alive, there is a race condition where it could
-        # be dying, use wait to make sure if necessary.
-        return self._proc.is_alive()
+        # if the proc is alive, there is a race condition where it could be
+        # dying, but the the barrier should be broken at that time.
+        # Barrier state is a little quicker to check so do that first
+        return not self._barrier.broken and self._proc.is_alive()
+
+    def wake_up(self, timeout=None):
+        # raise an exception if the barrier is broken or we must wait
+        try:
+            self._barrier.wait(timeout)
+        except BrokenBarrierError:
+            # raise our own flavor of exception and ensure death
+            self.kill()
+            raise BrokenWorkerError(f"{self._proc} died unexpectedly") from None
 
     def kill(self):
+        self._barrier.abort()
         try:
             self._proc.kill()
         except AttributeError:
@@ -273,7 +298,7 @@ async def to_process_run_sync(sync_fn, *args, cancellable=False, limiter=None):
     - Protect the main process from untrusted/unstable code without leaks
 
     Other :mod:`multiprocessing` features may work but are not officially
-    supported by Trio, and all the normal :mod:`multiprocessing` caveats apply.
+    supported, and all the normal :mod:`multiprocessing` caveats apply.
 
     Args:
       sync_fn: An importable or pickleable synchronous callable. See the
@@ -304,19 +329,14 @@ async def to_process_run_sync(sync_fn, *args, cancellable=False, limiter=None):
     async with limiter:
         PROC_CACHE.prune()
 
-        while True:
-            try:
-                proc = PROC_CACHE.pop()
-            except IndexError:
-                proc = await trio.to_thread.run_sync(WorkerProc)
+        try:
+            proc = PROC_CACHE.pop()
+        except IndexError:
+            proc = await trio.to_thread.run_sync(WorkerProc)
 
-            try:
-                with trio.CancelScope(shield=not cancellable):
-                    return await proc.run_sync(sync_fn, *args)
-            except trio.BrokenResourceError:
-                # Rare case where proc timed out even though it was still alive
-                # as we popped it. Just retry.
-                pass
-            finally:
-                if proc.is_alive():
-                    PROC_CACHE.push(proc)
+        try:
+            with trio.CancelScope(shield=not cancellable):
+                return await proc.run_sync(sync_fn, *args)
+        finally:
+            if proc.is_alive():
+                PROC_CACHE.push(proc)


### PR DESCRIPTION
While it is possible to run the workers on just Pipe thanks to `Pipe.poll`, a lot of implementation details start to leak, and the trio-parallel code complexity begins to grow. I'm also not certain if it is even possible to succeed on pypy due to `os.read` apparently [not raising an error if the pipe is closed](https://github.com/richardsheridan/trio-parallel/pull/8/checks?check_run_id=1807634029#step:5:664). And there is also an intractable race if a segfault or kill occurs between `poll` and `read` anyway and the `finally` block is not executed.