### PR TITLE
patch cancellation race

### DIFF
--- a/newsfragments/5.bugfix.rst
+++ b/newsfragments/5.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an underlying race condition in IPC. Not a critical bugfix, as it should not be triggered in practice.

--- a/trio_parallel/_windows_pipes.py
+++ b/trio_parallel/_windows_pipes.py
@@ -48,7 +48,8 @@ class PipeReceiveChannel(ReceiveChannel[bytes]):
                 newbuffer = bytearray(DEFAULT_RECEIVE_SIZE + left)
                 with memoryview(newbuffer) as view:
                     view[:DEFAULT_RECEIVE_SIZE] = buffer
-                    await self._receive_some_into(view[DEFAULT_RECEIVE_SIZE:])
+                    with trio.CancelScope(shield=True):
+                        await self._receive_some_into(view[DEFAULT_RECEIVE_SIZE:])
                 return newbuffer
             else:
                 del buffer[received:]


### PR DESCRIPTION
Fix an underlying race condition that could lead to split messages between processes. It is not a critical bugfix because I think that it is impossible to trigger within the _current_ trio-parallel code... but better to head things off now.