### PR TITLE
Refactor WorkerProc init, wake_up, and kill

### DIFF
--- a/newsfragments/20.bugfix.rst
+++ b/newsfragments/20.bugfix.rst
@@ -1,0 +1,1 @@
+Reduce the production of zombie children on Unix systems

--- a/trio_parallel/_tests/test_worker_processes.py
+++ b/trio_parallel/_tests/test_worker_processes.py
@@ -20,6 +20,7 @@ def empty_proc_cache():
         try:
             proc = PROC_CACHE.pop()
             proc.kill()
+            proc._proc.join()
         except IndexError:
             return
 
@@ -213,7 +214,7 @@ async def test_to_process_run_sync_raises_on_kill():
                 finally:
                     # if something goes wrong, free the thread
                     ev.set()
-                proc.kill()
+                proc.kill()  # also tests multiple calls to proc.kill
 
 
 async def test_wake_worker_in_thread_and_prune_cache():

--- a/trio_parallel/_tests/test_worker_processes.py
+++ b/trio_parallel/_tests/test_worker_processes.py
@@ -216,9 +216,10 @@ async def test_to_process_run_sync_raises_on_kill():
                 proc.kill()
 
 
-async def test_spawn_worker_in_thread_and_prune_cache():
-    # make sure we can successfully put worker spawning in a trio thread
-    proc = await trio.to_thread.run_sync(WorkerProc)
+async def test_wake_worker_in_thread_and_prune_cache():
+    # make sure we can successfully put worker waking in a Trio thread
+    proc = WorkerProc()
+    await trio.to_thread.run_sync(proc.wake_up)
     # take it's number and kill it for the next test
     pid1 = proc._proc.pid
     proc.kill()
@@ -250,6 +251,7 @@ async def test_exhaustively_cancel_run_sync():
 
     # cancel at job send
     proc = WorkerProc()
+    proc.wake_up()
     with trio.fail_after(1):
         with trio.move_on_after(0):
             await proc.run_sync(_never_halts, ev)

--- a/trio_parallel/_worker_processes.py
+++ b/trio_parallel/_worker_processes.py
@@ -24,7 +24,7 @@ class BrokenWorkerError(RuntimeError):
     """Raised when a worker process fails or dies unexpectedly.
 
     This error is not typically encountered in normal use, and indicates a severe
-    failure of either Trio or the code that was executing in the worker.
+    failure of either trio-parallel or the code that was executing in the worker.
     """
 
     pass

--- a/trio_parallel/_worker_processes.py
+++ b/trio_parallel/_worker_processes.py
@@ -122,8 +122,8 @@ class WorkerProcBase:
                 # Manually close coroutine to avoid RuntimeWarnings
                 ret.close()
                 raise TypeError(
-                    "Trio expected a sync function, but {!r} appears to be "
-                    "asynchronous".format(getattr(fn, "__qualname__", fn))
+                    "trio-parallel worker expected a sync function, but {!r} appears "
+                    "to be asynchronous".format(getattr(fn, "__qualname__", fn))
                 )
 
             return ret
@@ -150,7 +150,7 @@ class WorkerProcBase:
 
     async def run_sync(self, sync_fn, *args):
         # Neither this nor the child process should be waiting at this point
-        assert not self._barrier.n_waiting, "Must first wake_up() the WorkerProc"
+        assert not self._barrier.n_waiting, "Must first wake_up() the worker"
         self._rehabilitate_pipes()
         try:
             await self._send(ForkingPickler.dumps((sync_fn, args)))

--- a/trio_parallel/_worker_processes.py
+++ b/trio_parallel/_worker_processes.py
@@ -150,7 +150,6 @@ class WorkerProcBase:
     async def run_sync(self, sync_fn, *args):
         # Neither this nor the child process should be waiting at this point
         assert not self._barrier.n_waiting, "Must first wake_up() the worker"
-        # self._rehabilitate_pipes()
         try:
             await self._send(ForkingPickler.dumps((sync_fn, args)))
             result = ForkingPickler.loads(await self._recv())
@@ -184,7 +183,7 @@ class WorkerProcBase:
             self._barrier.wait(timeout)
         except BrokenBarrierError:
             # raise our own flavor of exception and reap child
-            if self._proc.is_alive():
+            if self._proc.is_alive():  # pragma: no cover - rare race condition
                 self.kill()
                 self._proc.join()  # this will block for ms, but it should be rare
             raise BrokenWorkerError(f"{self._proc} died unexpectedly") from None

--- a/trio_parallel/_worker_processes.py
+++ b/trio_parallel/_worker_processes.py
@@ -94,7 +94,9 @@ PROC_CACHE = ProcCache()
 
 class WorkerProcBase:
     def __init__(self, mp_context=get_context("spawn")):
-        # it is almost possible to synchronize on the pipe alone
+        # It is almost possible to synchronize on the pipe alone but on Pypy
+        # the _send_pipe doesn't raise the correct error on death. Anyway,
+        # this Barrier strategy is more obvious to understand.
         self._barrier = mp_context.Barrier(2)
         child_recv_pipe, self._send_pipe = mp_context.Pipe(duplex=False)
         self._recv_pipe, child_send_pipe = mp_context.Pipe(duplex=False)

--- a/trio_parallel/_worker_processes.py
+++ b/trio_parallel/_worker_processes.py
@@ -108,7 +108,6 @@ class WorkerProcBase:
         )
         # keep our own state flag for quick checks
         self._started = False
-        # self._proc.start()
         self._rehabilitate_pipes()
 
     @staticmethod
@@ -224,6 +223,8 @@ class WindowsWorkerProc(WorkerProcBase):
         if hasattr(self, "_send_chan"):
             self._send_chan._handle_holder.handle = -1
             self._recv_chan._handle_holder.handle = -1
+        else:  # pragma: no cover
+            pass
 
 
 class PosixWorkerProc(WorkerProcBase):
@@ -286,6 +287,8 @@ class PosixWorkerProc(WorkerProcBase):
         if hasattr(self, "_send_stream"):
             self._send_stream._fd_holder.fd = -1
             self._recv_stream._fd_holder.fd = -1
+        else:  # pragma: no cover
+            pass
 
 
 class PypyWorkerProc(WorkerProcBase):


### PR DESCRIPTION
Making `_proc.start()` a component of `wake_up()` removes some awkwardness from the instantiation of the class. Meanwhile, `kill` should not actually repeatedly try to kill the process, and on unix it `kill` leaves zombies behind, so it's necessary to obtain `_proc.exitcode` either by that property or `is_alive()` or `join()`.