### PR TITLE
Explicitly depend on outcome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license="MIT -or- Apache License 2.0",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["trio"],
+    install_requires=["trio", "outcome"],
     keywords=["parallel", "trio", "async", "dispatch"],
     python_requires=">=3.6",
     classifiers=[


### PR DESCRIPTION
Technically since the worker processes import outcome, we depend on outcome independently of our trio dependency