### PR TITLE
fix race condition

### DIFF
--- a/newsfragments/25.bugfix.rst
+++ b/newsfragments/25.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid a race condition leading to deadlocks when a worker process is killed right after receiving work.


### PR DESCRIPTION
Since our fundamental synchronization primitive is currently a `multiprocessing.synchronize.SemLock`, it is possible to get into a deadlock by killing a worker process too soon after passing the barrier, i.e., when it is holding it's condition variable lock after being notified by the main process. For now we will do a little spin wait that will skipped 95% of the time.