### PR TITLE
Avoid ForkingPickler and use latest pickle protocol

### DIFF
--- a/newsfragments/27.misc.rst
+++ b/newsfragments/27.misc.rst
@@ -1,0 +1,1 @@
+By avoiding ForkingPickler and use latest pickle protocol for IPC, unlock automatic performance improvements over time.


### PR DESCRIPTION
This unlocks some potential for automatic performance upgrades over time since we have simultaneous control of pickling and unpickling here. And we don't need to access a private API.