### PR TITLE
Synchronize on pipe only

### DIFF
--- a/newsfragments/33.bugfix.rst
+++ b/newsfragments/33.bugfix.rst
@@ -1,0 +1,1 @@
+Workers are now fully synchronized with only pipe/channel-like objects, making it impossible to leak semaphores.

--- a/trio_parallel/__init__.py
+++ b/trio_parallel/__init__.py
@@ -9,4 +9,4 @@ from ._impl import (
     to_process_run_sync as run_sync,
     current_default_worker_limiter,
 )
-from ._util import BrokenWorkerError
+from ._proc import BrokenWorkerError

--- a/trio_parallel/_impl.py
+++ b/trio_parallel/_impl.py
@@ -4,7 +4,6 @@ import trio
 from collections import deque
 
 from ._proc import WorkerProc
-from ._util import BrokenWorkerError
 
 
 _limiter_local = trio.lowlevel.RunVar("proc_limiter")
@@ -56,15 +55,10 @@ class WorkerCache:
         self._cache.append(proc)
 
     def pop(self):
-        # Get live, WOKEN worker process or raise IndexError
+        # Get live worker process or raise IndexError
         while True:
             proc = self._cache.pop()
-            try:
-                proc.wake_up(0)
-            except BrokenWorkerError:
-                # proc must have died in the cache, just try again
-                continue
-            else:
+            if proc.is_alive():
                 return proc
 
     def __len__(self):
@@ -120,15 +114,20 @@ async def to_process_run_sync(sync_fn, *args, cancellable=False, limiter=None):
     async with limiter:
         WORKER_CACHE.prune()
 
-        try:
-            proc = WORKER_CACHE.pop()
-        except IndexError:
-            proc = WorkerProc()
-            await trio.to_thread.run_sync(proc.wake_up)
+        while True:
+            try:
+                proc = WORKER_CACHE.pop()
+            except IndexError:
+                proc = WorkerProc()
 
-        try:
-            with trio.CancelScope(shield=not cancellable):
-                return await proc.run_sync(sync_fn, *args)
-        finally:
-            if proc.is_alive():
-                WORKER_CACHE.push(proc)
+            try:
+                with trio.CancelScope(shield=not cancellable):
+                    return await proc.run_sync(sync_fn, *args)
+            except trio.BrokenResourceError:  # pragma: no cover
+                # Rare case where proc timed out even though it was still alive
+                # as we popped it. Just retry. But reap zombie child first.
+                if proc.is_alive():
+                    await proc.wait()
+            finally:
+                if proc.is_alive():
+                    WORKER_CACHE.push(proc)

--- a/trio_parallel/_impl.py
+++ b/trio_parallel/_impl.py
@@ -128,6 +128,7 @@ async def to_process_run_sync(sync_fn, *args, cancellable=False, limiter=None):
                 # as we popped it. Just retry. But reap zombie child first.
                 if proc.is_alive():
                     await proc.wait()
+                continue
             finally:
                 if proc.is_alive():
                     WORKER_CACHE.push(proc)

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -240,8 +240,6 @@ class PosixWorkerProc(WorkerProcBase):
     async def _child_monitor(self):
         # If this worker dies, raise a catchable error...
         await self.wait()
-        # but not if another error or cancel is incoming, those take priority!
-        await trio.lowlevel.checkpoint_if_cancelled()
         raise BrokenWorkerError(f"{self._proc} died unexpectedly")
 
 

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -224,8 +224,6 @@ class PosixWorkerProc(WorkerProcBase):
         else:  # pragma: no cover
             pass
 
-
-class PypyWorkerProc(WorkerProcBase):
     async def run_sync(self, sync_fn, *args):
         async with trio.open_nursery() as nursery:
             nursery.start_soon(self._child_monitor)
@@ -244,12 +242,6 @@ class PypyWorkerProc(WorkerProcBase):
 if os.name == "nt":
 
     class WorkerProc(WindowsWorkerProc):
-        pass
-
-
-elif platform.python_implementation() == "PyPy":
-
-    class WorkerProc(PypyWorkerProc, PosixWorkerProc):
         pass
 
 

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -95,8 +95,6 @@ class WorkerProcBase(abc.ABC):
         return self._proc.is_alive()
 
     def kill(self):
-        if not self._started.is_set():
-            return
         try:
             self._proc.kill()
         except AttributeError:

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import struct
 import abc
 from itertools import count
@@ -8,7 +7,16 @@ from pickle import dumps, loads
 
 import trio
 
-from ._util import BrokenWorkerError
+
+class BrokenWorkerError(RuntimeError):
+    """Raised when a worker process fails or dies unexpectedly.
+
+    This error is not typically encountered in normal use, and indicates a severe
+    failure of either trio-parallel or the code that was executing in the worker.
+    """
+
+    pass
+
 
 # How long a process will idle waiting for new work before gives up and exits.
 # This should be longer than a thread timeout proportionately to startup time.

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -230,7 +230,10 @@ class PosixWorkerProc(WorkerProcBase):
     async def run_sync(self, sync_fn, *args):
         async with trio.open_nursery() as nursery:
             nursery.start_soon(self._child_monitor)
-            result = await super().run_sync(sync_fn, *args)
+            try:
+                result = await super().run_sync(sync_fn, *args)
+            except BrokenWorkerError:
+                await trio.sleep_forever()  # let the monitor reap and raise
             nursery.cancel_scope.cancel()
         return result
 

--- a/trio_parallel/_tests/test_proc.py
+++ b/trio_parallel/_tests/test_proc.py
@@ -1,12 +1,10 @@
 import multiprocessing
-import platform
 import signal
 
 import trio
 import pytest
 
-from .._util import BrokenWorkerError
-from .._proc import WorkerProc
+from .._proc import WorkerProc, BrokenWorkerError
 
 
 @pytest.fixture

--- a/trio_parallel/_tests/test_proc.py
+++ b/trio_parallel/_tests/test_proc.py
@@ -120,10 +120,10 @@ def _shorten_timeout():  # pragma: no cover
     _proc.IDLE_TIMEOUT = 0
 
 
-@pytest.mark.xfail(
-    platform.python_implementation() == "PyPy",
-    reason="Pipe closed by worker on PyPy does not raise OSError",
-)
+# @pytest.mark.xfail(
+#     platform.python_implementation() == "PyPy",
+#     reason="Pipe closed by worker on PyPy does not raise OSError",
+# )
 async def test_racing_timeout(proc):
     await proc.run_sync(_shorten_timeout)
     with trio.fail_after(1):

--- a/trio_parallel/_tests/test_proc.py
+++ b/trio_parallel/_tests/test_proc.py
@@ -120,10 +120,6 @@ def _shorten_timeout():  # pragma: no cover
     _proc.IDLE_TIMEOUT = 0
 
 
-# @pytest.mark.xfail(
-#     platform.python_implementation() == "PyPy",
-#     reason="Pipe closed by worker on PyPy does not raise OSError",
-# )
 async def test_racing_timeout(proc):
     await proc.run_sync(_shorten_timeout)
     with trio.fail_after(1):

--- a/trio_parallel/_tests/test_proc.py
+++ b/trio_parallel/_tests/test_proc.py
@@ -122,7 +122,7 @@ def _shorten_timeout():  # pragma: no cover
 async def test_racing_timeout(proc):
     await proc.run_sync(_shorten_timeout)
     with trio.fail_after(1):
-        await proc.wait()
+        assert not await proc.wait()  # should get a zero exit code
     with trio.fail_after(1):
         with pytest.raises(trio.BrokenResourceError):
             await proc.run_sync(int)

--- a/trio_parallel/_tests/test_proc.py
+++ b/trio_parallel/_tests/test_proc.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import platform
 import signal
 
 import trio
@@ -119,6 +120,10 @@ def _shorten_timeout():  # pragma: no cover
     _proc.IDLE_TIMEOUT = 0
 
 
+@pytest.mark.xfail(
+    platform.python_implementation() == "PyPy",
+    reason="Pipe closed by worker on PyPy does not raise OSError",
+)
 async def test_racing_timeout(proc):
     await proc.run_sync(_shorten_timeout)
     with trio.fail_after(1):

--- a/trio_parallel/_util.py
+++ b/trio_parallel/_util.py
@@ -1,8 +1,0 @@
-class BrokenWorkerError(RuntimeError):
-    """Raised when a worker process fails or dies unexpectedly.
-
-    This error is not typically encountered in normal use, and indicates a severe
-    failure of either trio-parallel or the code that was executing in the worker.
-    """
-
-    pass


### PR DESCRIPTION
Design sketch for dropping the Barrier synchronization scheme. This was partially successful before but had some trouble on pypy, and I keep getting curious about fixing it.