### PR TITLE
Block keyboard interrupts in workers

### DIFF
--- a/newsfragments/35.bugfix.rst
+++ b/newsfragments/35.bugfix.rst
@@ -1,0 +1,1 @@
+Ignore keyboard interrupt (SIGINT) in workers to ensure correct cancellation semantics and clean shutdown on CTRL+C.

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -40,6 +40,7 @@ class WorkerProcBase(abc.ABC):
     def _work(barrier, recv_pipe, send_pipe):  # pragma: no cover
 
         import inspect
+        import signal
         import outcome
 
         def coroutine_checker(fn, args):
@@ -53,6 +54,10 @@ class WorkerProcBase(abc.ABC):
                 )
 
             return ret
+
+        # Intercept keyboard interrupts to avoid passing KeyboardInterrupt
+        # between processes. (Trio will take charge via cancellation.)
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
 
         while True:
             try:


### PR DESCRIPTION
Fixes #34. SIGINT is set to be ignored as soon as the process starts up. This makes sure our `Outcome` never wraps up a `KeyboardInterrupt` and sends it across processes. There are tradeoffs here:

  1. `cancellable=False` runs really cannot be cancelled with ctrl+c anymore. This seems desirable, but should be documented.
  2. A rogue function can modify our signal handling and there's nothing we can do about it unless we want to reset the handler every time. I think this is enough of an edge case to not burn the cpu cycles.