### PR TITLE
fix license_files syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ long_description = file: README.rst
 author = Richard Sheridan
 author_email = richard.sheridan@gmail.com
 license = MIT -or- Apache License 2.0
-license_files = LICENSE, LICENSE.APACHE2, LICENSE.MIT
+license_files = LICENSE LICENSE.APACHE2 LICENSE.MIT
 keywords = parallel, trio, async, dispatch
 classifiers =
     License :: OSI Approved :: MIT License


### PR DESCRIPTION
Apparently we have not been shipping all three license files in our wheels!