### PR TITLE
Automate versioning with setuptools-scm

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup python
         uses: actions/setup-python@v2
       - name: Build sdist wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Build sdist wheel
         run: |
           python -m pip install -U pip
-          python -m pip install -U build wheel
-          python -m build --no-isolation  # this job is already super isolated
+          python -m pip install -U build
+          python -m build  # Isolation seems redundant, but helps pull dependencies
       - name: Output wheelname
         id: wheelname
         run: echo "::set-output name=wheelname::$(ls ./dist/*.whl)"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 # Add any project-specific files here:
+trio_parallel/_version.py
+
+# IDEs
 .idea/
 
 # Sphinx docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 # Add any project-specific files here:
-trio_parallel/_version.py
-
-# IDEs
 .idea/
 
 # Sphinx docs

--- a/CHEATSHEET.rst
+++ b/CHEATSHEET.rst
@@ -39,7 +39,7 @@ To make a release
 
 * Run ``towncrier`` to collect your release notes.
 
-* Review your release notes.
+* Review your release notes and update version in the new history header.
 
 * Double-check it all works, docs build, etc.
 

--- a/CHEATSHEET.rst
+++ b/CHEATSHEET.rst
@@ -37,22 +37,24 @@ To run black
 To make a release
 -----------------
 
-* Update the version in ``trio_parallel/_version.py``
-
 * Run ``towncrier`` to collect your release notes.
 
 * Review your release notes.
+
+  * Correct the version number!
 
 * Double-check it all works, docs build, etc.
 
 * Check everything in.
 
-* Make a release PR on GitHub. Checks should pass.
+* Make a release PR on GitHub. Checks must pass.
+
+* Use GitHub release mechanism to tag the release commit: ``hub release create {version}``
 
 * Build your sdist and wheel: ``python -m build``
 
+* Check wheel and sdist, especially version in filenames.
+
 * Upload to PyPI: ``twine upload dist/*``
 
-* Use GitHub release mechanism to tag the release in git and upload sdist and wheel.
-
-* add "+dev" to version and commit to main.
+* Upload to GitHub: ``hub release edit -a dist/*.whl``

--- a/CHEATSHEET.rst
+++ b/CHEATSHEET.rst
@@ -41,8 +41,6 @@ To make a release
 
 * Review your release notes.
 
-  * Correct the version number!
-
 * Double-check it all works, docs build, etc.
 
 * Check everything in.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-include CHEATSHEET* CODE_OF_CONDUCT* CONTRIBUTING*
-include *requirements.txt
-recursive-include docs *
-prune docs/build

--- a/newsfragments/40.misc.rst
+++ b/newsfragments/40.misc.rst
@@ -1,0 +1,1 @@
+Automate versioning with setuptools-scm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,11 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "wheel"]
+requires = ["setuptools >= 45", "wheel", "setuptools_scm[toml] >= 6.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "trio_parallel/_version.py"
+write_to_template = '__version__ = "{version}"'
+fallback_version = 'unversioned'
 
 [tool.towncrier]
 package = "trio_parallel"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 45", "wheel", "setuptools_scm[toml] >= 6.0", 'setuptools_scm_git_archive']
+requires = ["setuptools >= 45", "wheel", "setuptools_scm[toml] >= 6.0", "setuptools_scm_git_archive"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,8 @@
 [build-system]
-requires = ["setuptools >= 45", "wheel", "setuptools_scm[toml] >= 6.0"]
+requires = ["setuptools >= 45", "wheel", "setuptools_scm[toml] >= 6.0", 'setuptools_scm_git_archive']
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-write_to = "trio_parallel/_version.py"
-write_to_template = '__version__ = "{version}"'
-fallback_version = 'unversioned'
 
 [tool.towncrier]
 package = "trio_parallel"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Dummy requirements until things like libraries.io and github can understand PEP517/518
 trio >= 0.18.0
 outcome
+importlib-metadata

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ include_package_data = True
 install_requires =
     trio >= 0.18.0
     outcome
+    importlib-metadata
 python_requires = >=3.6
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = trio-parallel
-version = attr: trio_parallel._version.__version__
 description = CPU parallelism for Trio
 url = https://github.com/richardsheridan/trio-parallel
 long_description = file: README.rst

--- a/trio_parallel/__init__.py
+++ b/trio_parallel/__init__.py
@@ -1,10 +1,8 @@
 """Top-level package for trio-parallel."""
 
-try:
-    from ._version import __version__
-except ImportError:
-    import warnings
-    warnings.warn("trio_parallel._version module missing, continuing without __version__")
+from importlib_metadata import version
+__version__ = version("trio-parallel")
+del version
 
 from ._impl import (
     to_process_run_sync as run_sync,

--- a/trio_parallel/__init__.py
+++ b/trio_parallel/__init__.py
@@ -1,6 +1,7 @@
 """Top-level package for trio-parallel."""
 
 from importlib_metadata import version
+
 __version__ = version("trio-parallel")
 del version
 

--- a/trio_parallel/__init__.py
+++ b/trio_parallel/__init__.py
@@ -1,6 +1,10 @@
 """Top-level package for trio-parallel."""
 
-from ._version import __version__
+try:
+    from ._version import __version__
+except ImportError:
+    import warnings
+    warnings.warn("trio_parallel._version module missing, continuing without __version__")
 
 from ._impl import (
     to_process_run_sync as run_sync,

--- a/trio_parallel/_version.py
+++ b/trio_parallel/_version.py
@@ -1,3 +1,0 @@
-# This file is imported from __init__.py and exec'd from setup.py
-
-__version__ = "0.4.0+dev"


### PR DESCRIPTION
- Advantages
  - pyproject.toml config rather than setup.cfg
  - datestamp in dirty tag is nice
  - no large vendored public domain module
  - eliminate `MANIFEST.in`
- Disadvantages
  - obscure extra `.git_archival.txt`
  - ossifies dependency on setuptools
  - extra `importlib-metadata` dependency for python < 3.8