### PR TITLE
minor test cleanups

### DIFF
--- a/newsfragments/42.misc.rst
+++ b/newsfragments/42.misc.rst
@@ -1,0 +1,2 @@
+Apply minor cleanups to tests. Mostly just renames and comment shuffles, but also remove a barrier synchronization case.
+


### PR DESCRIPTION
mostly just renames and comment shuffles, but also remove a weird try/except relating to the old barrier synchronization.