### PR TITLE
Revise run_sync error semantics

### DIFF
--- a/trio_parallel/_impl.py
+++ b/trio_parallel/_impl.py
@@ -114,22 +114,15 @@ async def to_process_run_sync(sync_fn, *args, cancellable=False, limiter=None):
     async with limiter:
         WORKER_CACHE.prune()
 
-        while True:
+        result = None
+        while result is None:
             try:
                 proc = WORKER_CACHE.pop()
             except IndexError:
                 proc = WorkerProc()
 
-            try:
-                with trio.CancelScope(shield=not cancellable):
-                    result = await proc.run_sync(sync_fn, *args)
-                if result is None:  # pragma: no cover
-                    # Rare case where proc timed out even though it was still alive
-                    # as we popped it. Just retry. But reap zombie child first.
-                    if proc.is_alive():
-                        await proc.wait()
-                else:
-                    return result.unwrap()
-            finally:
-                if proc.is_alive():
-                    WORKER_CACHE.push(proc)
+            with trio.CancelScope(shield=not cancellable):
+                result = await proc.run_sync(sync_fn, *args)
+
+    WORKER_CACHE.push(proc)
+    return result.unwrap()

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -251,21 +251,6 @@ class PosixWorkerProc(WorkerProcBase):
         else:  # pragma: no cover
             pass
 
-    async def run_sync(self, sync_fn, *args):
-        async with trio.open_nursery() as nursery:
-            nursery.start_soon(self._child_monitor)
-            try:
-                result = await super().run_sync(sync_fn, *args)
-            except BrokenWorkerError:
-                await trio.sleep_forever()  # let the monitor reap and raise
-            nursery.cancel_scope.cancel()
-        return result
-
-    async def _child_monitor(self):
-        # If this worker dies, raise a catchable error...
-        await self.wait()
-        raise BrokenWorkerError(f"{self._proc} died unexpectedly")
-
 
 if os.name == "nt":
 

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -89,6 +89,7 @@ class WorkerProcBase(abc.ABC):
             send_pipe.close()
 
     async def run_sync(self, sync_fn, *args) -> Optional[Outcome]:
+        result = None
         try:
             if not self._started.is_set():
                 await trio.to_thread.run_sync(self._proc.start)
@@ -97,20 +98,20 @@ class WorkerProcBase(abc.ABC):
                 self._child_recv_pipe.close()
                 self._started.set()
             await self._send(dumps((sync_fn, args), protocol=-1))
-            return loads(await self._recv())
+            result = loads(await self._recv())
         except trio.EndOfChannel:
             # Likely the worker died while we were waiting on _recv
-            self.kill()  # NOTE: must reap zombie child elsewhere
             raise BrokenWorkerError(f"{self._proc} died unexpectedly")
         except trio.BrokenResourceError:
             # Likely the worker died while we were waiting on _send
-            self.kill()  # NOTE: must reap zombie child elsewhere
             return None
-        except BaseException:
-            # Cancellation or other unknown errors leave the process in an
-            # unknown state, so there is no choice but to kill.
-            self.kill()  # NOTE: must reap zombie child elsewhere
-            raise
+        finally:
+            if result is None:
+                self.kill()
+                with trio.CancelScope(shield=True):
+                    await self.wait()
+            else:
+                return result
 
     def is_alive(self):
         # if the proc is alive, there is a race condition where it could be


### PR DESCRIPTION
`WorkerProc.run_sync` is now responsible for reaping any zombies it creates