### PR TITLE
Revise run_sync logic yet again

### DIFF
--- a/newsfragments/48.feature.rst
+++ b/newsfragments/48.feature.rst
@@ -1,0 +1,1 @@
+:exc:`trio_parallel.BrokenWorkerError` now contains a reference to the underlying worker process which can be inspected e.g. to handle specific exit codes.

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -124,7 +124,7 @@ class WorkerProcBase(abc.ABC):
             self._proc.terminate()
 
     def __repr__(self):
-        return repr(self._proc)
+        return repr(self._proc)  # pragma: no cover
 
     @abc.abstractmethod
     async def wait(self):

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -94,17 +94,18 @@ class WorkerProcBase(abc.ABC):
                 self._child_send_pipe.close()
                 self._child_recv_pipe.close()
                 self._started.set()
+
             try:
                 await self._send(dumps((sync_fn, args), protocol=-1))
             except trio.BrokenResourceError:
                 return None
+
             try:
-                result = loads(await self._recv())
+                return loads(await self._recv())
             except trio.EndOfChannel:
                 await self.wait()
                 raise BrokenWorkerError("Worker died unexpectedly:", self)
 
-            return result
         except BaseException:
             self.kill()
             raise

--- a/trio_parallel/_tests/test_proc.py
+++ b/trio_parallel/_tests/test_proc.py
@@ -45,11 +45,12 @@ async def test_run_sync_cancel_infinite_loop(proc, manager):
 # TODO: debug manager interaction with pipes on PyPy GH#44
 async def test_run_sync_raises_on_kill(proc):
     await proc.run_sync(int)  # running start so actual test is less racy
-    with pytest.raises(BrokenWorkerError), trio.fail_after(5):
+    with pytest.raises(BrokenWorkerError) as exc_info, trio.fail_after(5):
         async with trio.open_nursery() as nursery:
             nursery.start_soon(proc.run_sync, time.sleep, 5)
             await trio.sleep(0.1)
             proc.kill()  # also tests multiple calls to proc.kill
+    assert exc_info.value.args[-1].exitcode is not None
 
 
 def _segfault_out_of_bounds_pointer():  # pragma: no cover
@@ -78,8 +79,8 @@ async def test_run_sync_raises_on_segfault(proc):
     try:
         with trio.fail_after(55):
             await proc.run_sync(_segfault_out_of_bounds_pointer)
-    except BrokenWorkerError:
-        pass
+    except BrokenWorkerError as e:
+        assert e.args[-1].exitcode is not None
     except trio.TooSlowError:  # pragma: no cover
         pytest.xfail("Unable to cause segfault after 55 seconds.")
     else:  # pragma: no cover


### PR DESCRIPTION
This way, we can include `exitcode` in `BrokenWorkerError` through a reference to the actual `WorkerProc`. 

Also it is somewhat elegant to reap zombies with unstructured task in this layout, and only do so on unix. Need to ensure it does not lead to deadlocks on `trio.run` exit, though.