### PR TITLE
use sync API for graceful shutdown

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -10,6 +10,8 @@ Running CPU-bound functions in parallel
 
 .. autofunction:: current_default_worker_limiter
 
+.. autofunction:: default_shutdown_grace_period
+
 Configuring workers
 -------------------
 

--- a/newsfragments/108.feature.rst
+++ b/newsfragments/108.feature.rst
@@ -1,0 +1,3 @@
+Added configuration options for the grace periods permitted to worker caches upon
+shutdown. This includes a new keyword argument for :func:`cache_scope` and the new top
+level function :func:`default_cache_grace_period`.

--- a/newsfragments/108.feature.rst
+++ b/newsfragments/108.feature.rst
@@ -1,3 +1,3 @@
 Added configuration options for the grace periods permitted to worker caches upon
 shutdown. This includes a new keyword argument for :func:`cache_scope` and the new top
-level function :func:`default_cache_grace_period`.
+level function :func:`default_shutdown_grace_period`.

--- a/trio_parallel/__init__.py
+++ b/trio_parallel/__init__.py
@@ -5,5 +5,6 @@ from ._impl import (
     cache_scope,
     WorkerType,
     current_default_worker_limiter,
+    default_shutdown_grace_period,
 )
 from ._abc import BrokenWorkerError

--- a/trio_parallel/_abc.py
+++ b/trio_parallel/_abc.py
@@ -26,8 +26,16 @@ class WorkerCache(deque, ABC):
         while idle in the cache."""
 
     @abstractmethod
-    async def shutdown(self):
-        """Stop and clean up any resources associated with all cached workers."""
+    def shutdown(self, grace_period):
+        """Stop and clean up any resources associated with all cached workers.
+
+        Args:
+          grace_period: Time in seconds to wait for graceful shutdown before
+              raising.
+
+        Raises:
+          BrokenWorkerError: Raised if any workers fail to respond to a graceful
+              shutdown signal within ``grace_period``."""
 
 
 class AbstractWorker(ABC):

--- a/trio_parallel/_impl.py
+++ b/trio_parallel/_impl.py
@@ -58,7 +58,32 @@ class WorkerContext:
 
 DEFAULT_CONTEXT = WorkerContext()  # Mutable and monkeypatch-able!
 _worker_context_var = contextvars.ContextVar("worker_context", default=DEFAULT_CONTEXT)
-DEFAULT_SHUTDOWN_GRACE_PERIOD = 30
+DEFAULT_SHUTDOWN_GRACE_PERIOD = 30.0
+
+
+def default_shutdown_grace_period(grace_period=-1.0):
+    """Return and optionally set the default worker cache shutdown grace period.
+
+    Args:
+      grace_period (Optional[float]): The time in seconds to wait for workers to
+          exit before issuing SIGKILL/TerminateProcess and raising `BrokenWorkerError`.
+          Pass `None` to wait forever, as `math.inf` will fail. Pass a negative value
+          to return the current value without modifying it.
+
+    Returns:
+      Optional[float]: The current grace period in seconds or None.
+
+    .. note::
+
+       This function is subject to threading race conditions."""
+
+    global DEFAULT_SHUTDOWN_GRACE_PERIOD
+
+    if grace_period is None:
+        DEFAULT_SHUTDOWN_GRACE_PERIOD = None
+    elif grace_period >= 0.0:
+        DEFAULT_SHUTDOWN_GRACE_PERIOD = grace_period
+    return DEFAULT_SHUTDOWN_GRACE_PERIOD
 
 
 @atexit.register
@@ -71,6 +96,7 @@ def graceful_default_shutdown():
 async def cache_scope(
     idle_timeout=DEFAULT_CONTEXT.idle_timeout,
     retire=DEFAULT_CONTEXT.retire,
+    grace_period=DEFAULT_SHUTDOWN_GRACE_PERIOD,
     worker_type=WorkerType.SPAWN,
 ):
     """Create a new, customized worker cache with workers confined to
@@ -101,6 +127,10 @@ async def cache_scope(
           to find a valid worker. MUST be callable without arguments. MUST not
           raise (will result in a :class:`BrokenWorkerError` at an indeterminate
           future :func:`run_sync` call.)
+      grace_period (Optional[float]): The time in seconds to wait for workers to
+          exit before issuing SIGKILL/TerminateProcess and raising `BrokenWorkerError`.
+          Pass `None` to wait forever, as `math.inf` will fail.
+          MUST be non-negative if not `None`.
       worker_type (WorkerType): The kind of worker to create, see :class:`WorkerType`.
 
     Raises:
@@ -115,6 +145,8 @@ async def cache_scope(
         raise ValueError("idle_timeout must be non-negative or None")
     elif not callable(retire):
         raise ValueError("retire must be callable (with no arguments)")
+    elif grace_period is not None and grace_period < 0.0:
+        raise ValueError("grace_period must be non-negative or None")
     # TODO: better ergonomics for truthy first call to retire()
     worker_class, worker_cache = WORKER_MAP[worker_type]
     worker_context = WorkerContext(idle_timeout, retire, worker_class, worker_cache())
@@ -125,7 +157,7 @@ async def cache_scope(
         _worker_context_var.reset(token)
         with trio.CancelScope(shield=True):
             await trio.to_thread.run_sync(
-                worker_context.worker_cache.shutdown, DEFAULT_SHUTDOWN_GRACE_PERIOD
+                worker_context.worker_cache.shutdown, grace_period
             )
 
 

--- a/trio_parallel/_impl.py
+++ b/trio_parallel/_impl.py
@@ -71,7 +71,7 @@ def default_shutdown_grace_period(grace_period=-1.0):
           to return the current value without modifying it.
 
     Returns:
-      Optional[float]: The current grace period in seconds or None.
+      Optional[float]: The current grace period in seconds or `None`.
 
     .. note::
 

--- a/trio_parallel/_tests/test_impl.py
+++ b/trio_parallel/_tests/test_impl.py
@@ -256,7 +256,7 @@ def _loopy_retire_fn():  # pragma: no cover, will be killed
 
 async def test_loopy_retire_fn(manager):
     b = manager.Barrier(2)
-    with pytest.raises(BrokenWorkerError), trio.fail_after(5) as cancel_scope:
+    with pytest.raises(BrokenWorkerError), trio.fail_after(15) as cancel_scope:
         async with cache_scope(retire=_loopy_retire_fn, grace_period=0.5):
             # open an extra worker to increase branch coverage in cache shutdown()
             async with trio.open_nursery() as n:


### PR DESCRIPTION
If this function is sync flavored, we don't have to create a trio run in an atexit handler.  The disadvantage is that we need a thread to use it in the `cache_scope` API, but this is actually a reduction of threads on Windows, and the sync code is fairly efficient relative to the async code so it may wind up being a net performance boost while keeping the same exit-immediately-after-all-reaped semantics.