### PR TITLE
implement worker init fn

### DIFF
--- a/docs/source/examples/single_use_workers.py
+++ b/docs/source/examples/single_use_workers.py
@@ -29,13 +29,13 @@ async def amain():
     trio_parallel.current_default_worker_limiter().total_tokens = 4
 
     print("single use worker behavior:")
-    with trio_parallel.cache_scope(retire=after_single_use):
+    async with trio_parallel.cache_scope(retire=after_single_use):
         async with trio.open_nursery() as nursery:
             for i in range(40):
                 nursery.start_soon(trio_parallel.run_sync, worker, i)
 
     print("dual use worker behavior:")
-    with trio_parallel.cache_scope(retire=after_dual_use):
+    async with trio_parallel.cache_scope(retire=after_dual_use):
         async with trio.open_nursery() as nursery:
             for i in range(40):
                 nursery.start_soon(trio_parallel.run_sync, worker, i)

--- a/docs/source/examples/single_use_workers.py
+++ b/docs/source/examples/single_use_workers.py
@@ -9,16 +9,20 @@ def worker(i):
     print(i, "hello from", os.getpid())
 
 
+def after_single_use():
+    return True
+
+
 WORKER_HAS_BEEN_USED = False
 
 
-def after_single_use():
+def after_dual_use():
     global WORKER_HAS_BEEN_USED
     if WORKER_HAS_BEEN_USED:
         return True  # retire
     else:
         WORKER_HAS_BEEN_USED = True
-        return False  # don't retire
+        return False  # don't retire... YET
 
 
 async def amain():
@@ -26,6 +30,12 @@ async def amain():
 
     print("single use worker behavior:")
     with trio_parallel.cache_scope(retire=after_single_use):
+        async with trio.open_nursery() as nursery:
+            for i in range(40):
+                nursery.start_soon(trio_parallel.run_sync, worker, i)
+
+    print("dual use worker behavior:")
+    with trio_parallel.cache_scope(retire=after_dual_use):
         async with trio.open_nursery() as nursery:
             for i in range(40):
                 nursery.start_soon(trio_parallel.run_sync, worker, i)

--- a/newsfragments/110.feature.rst
+++ b/newsfragments/110.feature.rst
@@ -1,0 +1,2 @@
+:func:`cache_scope` gained a new argument, ``init``, and ``retire`` is no longer
+called before the first job in the worker.

--- a/trio_parallel/_abc.py
+++ b/trio_parallel/_abc.py
@@ -40,7 +40,12 @@ class WorkerCache(deque, ABC):
 
 class AbstractWorker(ABC):
     @abstractmethod
-    def __init__(self, idle_timeout: float, retire: Optional[Callable[[], bool]]):
+    def __init__(
+        self,
+        idle_timeout: float,
+        init: Optional[Callable[[], bool]],
+        retire: Optional[Callable[[], bool]],
+    ):
         pass
 
     @abstractmethod

--- a/trio_parallel/_tests/test_cache.py
+++ b/trio_parallel/_tests/test_cache.py
@@ -20,11 +20,11 @@ def cache_and_workertype(request):
 async def test_prune_cache(cache_and_workertype):
     # setup phase
     cache, worker_type = cache_and_workertype
-    dead_worker = worker_type(0, bool)
+    dead_worker = worker_type(0, bool, bool)
     assert not (await dead_worker.run_sync(bool)).unwrap()
     with trio.fail_after(1):
         await dead_worker.wait()
-    live_worker = worker_type(None, bool)
+    live_worker = worker_type(None, bool, bool)
     assert not (await live_worker.run_sync(bool)).unwrap()
     # put dead worker into the cache on the left
     cache.extend(iter([dead_worker, live_worker]))
@@ -68,6 +68,7 @@ async def test_bad_retire_fn(cache_and_workertype, capfd):
     if worker_type.mp_context._name == "forkserver":
         pytest.skip("capfd doesn't work on WorkerForkserverProc")
     worker = worker_type(None, bool, _bad_retire_fn)
+    await worker.run_sync(bool)
     with pytest.raises(BrokenWorkerError):
         await worker.run_sync(bool)
     with trio.fail_after(1):

--- a/trio_parallel/_tests/test_proc.py
+++ b/trio_parallel/_tests/test_proc.py
@@ -14,7 +14,7 @@ from .._abc import BrokenWorkerError
 
 @pytest.fixture(params=list(WORKER_PROC_MAP.values()), ids=list(WORKER_PROC_MAP.keys()))
 async def worker(request):
-    worker = request.param[0](None, bool)
+    worker = request.param[0](None, bool, bool)
     try:
         yield worker
     finally:

--- a/trio_parallel/_tests/test_run_sync.py
+++ b/trio_parallel/_tests/test_run_sync.py
@@ -20,7 +20,7 @@ def _special_none_making_retire():  # pragma: no cover, never called
 
 
 class MockWorker(AbstractWorker):
-    def __init__(self, idle_timeout: float, retire: Optional[Callable[[], bool]]):
+    def __init__(self, idle_timeout, init, retire):
         self.idle_timeout = idle_timeout
         self.retire = retire
 
@@ -160,7 +160,7 @@ async def test_erroneous_scope_inputs(mock_context):
         async with cache_scope(retire=0):
             assert False, "should be unreachable"
     assert not MockContext.active_contexts
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         async with cache_scope(worker_type="wrong"):
             assert False, "should be unreachable"
     with pytest.raises(ValueError):

--- a/trio_parallel/_tests/test_worker.py
+++ b/trio_parallel/_tests/test_worker.py
@@ -11,7 +11,7 @@ from .._impl import WORKER_MAP
 
 @pytest.fixture(params=list(WORKER_MAP.values()), ids=list(WORKER_MAP.keys()))
 async def worker(request):
-    worker = request.param[0](None, bool)
+    worker = request.param[0](None, bool, bool)
     try:
         yield worker
     finally:


### PR DESCRIPTION
It was possible to initialize a worker using `retire()` previously but that was hard to explain in the docs. Formally splitting init and retire phases clarifies this and makes a worker returning true on first call to be not a problem.