### PR TITLE
check coverage directly in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,14 +146,15 @@ jobs:
           python -m pip install -r requirements/test.txt
           python -m pip install ${{ needs.Build.outputs.wheelname }} --no-deps
           pytest trio_parallel --cov-report xml:coverage-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.python }}.xml
+          coverage report
+          mv .coverage .coverage.-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.python }}
         shell: bash
       - name: Upload coverage
         if: always()
         uses: actions/upload-artifact@v2.2.4
         with:
           name: Coverage
-          # Codecov-bash-uploader's match is '*coverage*.*'
-          path: coverage-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.python }}.xml
+          path: "*coverage*.*"
           if-no-files-found: error
 
   Codecov: # Codecov is naughty and will be forever isolated
@@ -174,10 +175,40 @@ jobs:
         with:
           fail_ci_if_error: true
 
+  Coverage:
+    name: Coverage
+    if: always()
+    needs: Test
+    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v2.0.10
+        with:
+          name: Coverage
+      - name: Setup python
+        uses: actions/setup-python@v2.2.2
+      - name: Install coverage
+        run: pip install coverage[toml]
+      - name: Run coverage
+        run: |
+          coverage combine
+          coverage html
+          coverage report --fail-under=100
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: Report
+          path: htmlcov/
+          if-no-files-found: error
+
   Publish:
     name: Publish
     if: github.event_name == 'release'
-    needs: [ Blacken, Build, Test, Codecov ]
+    needs: [ Blacken, Build, Test, Codecov, Coverage ]
     timeout-minutes: 1
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
         run: |
           coverage combine
           coverage html
-          coverage report --fail-under=100
+          coverage report --fail-under=100 --show-missing
       - name: Upload report
         if: always()
         uses: actions/upload-artifact@v2.2.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,14 +147,14 @@ jobs:
           python -m pip install ${{ needs.Build.outputs.wheelname }} --no-deps
           pytest trio_parallel --cov-report xml:coverage-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.python }}.xml
           coverage report
-          mv .coverage .coverage.-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.python }}
+          mv .coverage .coverage.${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.python }}
         shell: bash
       - name: Upload coverage
         if: always()
         uses: actions/upload-artifact@v2.2.4
         with:
           name: Coverage
-          path: "*coverage*.*"
+          path: "*coverage*${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.python }}*"
           if-no-files-found: error
 
   Codecov: # Codecov is naughty and will be forever isolated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ faulthandler_timeout = 60
 [tool.coverage.run]
 branch = true
 source_pkgs = ["trio_parallel"]
-relative_files = true
 disable_warnings = ["trace-changed"]  # for test_clean_exit_on_pipe_close
 
 [tool.coverage.report]
@@ -35,4 +34,4 @@ exclude_lines = [
 show_contexts = true
 
 [tool.coverage.paths]
-source = ["*/trio_parallel"]
+source = ["trio_parallel/", "*/trio_parallel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,6 @@ exclude_lines = [
 
 [tool.coverage.html]
 show_contexts = true
+
+[tool.coverage.paths]
+source = ["*/trio_parallel"]

--- a/trio_parallel/_tests/test_proc.py
+++ b/trio_parallel/_tests/test_proc.py
@@ -102,15 +102,15 @@ async def test_run_sync_raises_on_segfault(worker, capfd):
 # currently requires manually targeting all but last checkpoints
 
 
-# async def test_exhaustively_cancel_run_sync1(worker):
-#     if worker.mp_context._name == "fork":
-#         pytest.skip("Doesn't exist on WorkerForkProc")
-#     # cancel at startup
-#     with trio.fail_after(1):
-#         with trio.move_on_after(0) as cs:
-#             assert (await worker.run_sync(int)).unwrap()  # will return zero
-#         assert cs.cancelled_caught
-#         assert await worker.wait() is None
+async def test_exhaustively_cancel_run_sync1(worker):
+    if worker.mp_context._name == "fork":
+        pytest.skip("Doesn't exist on WorkerForkProc")
+    # cancel at startup
+    with trio.fail_after(1):
+        with trio.move_on_after(0) as cs:
+            assert (await worker.run_sync(int)).unwrap()  # will return zero
+        assert cs.cancelled_caught
+        assert await worker.wait() is None
 
 
 async def test_exhaustively_cancel_run_sync2(worker, manager):

--- a/trio_parallel/_tests/test_proc.py
+++ b/trio_parallel/_tests/test_proc.py
@@ -102,15 +102,15 @@ async def test_run_sync_raises_on_segfault(worker, capfd):
 # currently requires manually targeting all but last checkpoints
 
 
-async def test_exhaustively_cancel_run_sync1(worker):
-    if worker.mp_context._name == "fork":
-        pytest.skip("Doesn't exist on WorkerForkProc")
-    # cancel at startup
-    with trio.fail_after(1):
-        with trio.move_on_after(0) as cs:
-            assert (await worker.run_sync(int)).unwrap()  # will return zero
-        assert cs.cancelled_caught
-        assert await worker.wait() is None
+# async def test_exhaustively_cancel_run_sync1(worker):
+#     if worker.mp_context._name == "fork":
+#         pytest.skip("Doesn't exist on WorkerForkProc")
+#     # cancel at startup
+#     with trio.fail_after(1):
+#         with trio.move_on_after(0) as cs:
+#             assert (await worker.run_sync(int)).unwrap()  # will return zero
+#         assert cs.cancelled_caught
+#         assert await worker.wait() is None
 
 
 async def test_exhaustively_cancel_run_sync2(worker, manager):


### PR DESCRIPTION
It occurred to me that missing coverage does not actually "fail" CI, rather only the PR merge checks. Since all the data we need is already within GHA let's also combine and report coverage ourselves. This way we can get html reports that are IMO better than codecov anyway.

This makes codecov redundant but I guess it is a good redundancy in case I misconfigure the coverage combine.