### PR TITLE
Implement explicit context objects instead of cache scopes

### DIFF
--- a/docs/source/examples/single_use_workers.py
+++ b/docs/source/examples/single_use_workers.py
@@ -29,16 +29,16 @@ async def amain():
     trio_parallel.current_default_worker_limiter().total_tokens = 4
 
     print("single use worker behavior:")
-    async with trio_parallel.cache_scope(retire=after_single_use):
+    async with trio_parallel.WorkerContext(retire=after_single_use) as ctx:
         async with trio.open_nursery() as nursery:
             for i in range(40):
-                nursery.start_soon(trio_parallel.run_sync, worker, i)
+                nursery.start_soon(ctx.run_sync, worker, i)
 
     print("dual use worker behavior:")
-    async with trio_parallel.cache_scope(retire=after_dual_use):
+    async with trio_parallel.WorkerContext(retire=after_dual_use) as ctx:
         async with trio.open_nursery() as nursery:
             for i in range(40):
-                nursery.start_soon(trio_parallel.run_sync, worker, i)
+                nursery.start_soon(ctx.run_sync, worker, i)
 
     print("default behavior:")
     async with trio.open_nursery() as nursery:

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -15,7 +15,11 @@ Running CPU-bound functions in parallel
 Configuring workers
 -------------------
 
-.. autofunction:: cache_scope
+.. autoclass:: WorkerContext
+
+   .. automethod:: run_sync
+
+   .. automethod:: aclose
 
 .. autoclass:: WorkerType
 

--- a/trio_parallel/__init__.py
+++ b/trio_parallel/__init__.py
@@ -2,7 +2,7 @@
 
 from ._impl import (
     run_sync,
-    cache_scope,
+    WorkerContext,
     WorkerType,
     current_default_worker_limiter,
     default_shutdown_grace_period,


### PR DESCRIPTION
Would supersede #89. I don't really like the idea of juggling context options but it does circumvent the need for `TreeVars`.  Then, later, if those are implemented in trio, it will be pretty trivial to reimplement `cache_scope`.