### PR TITLE
Create context statistics API

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -12,6 +12,8 @@ Running CPU-bound functions in parallel
 
 .. autofunction:: atexit_shutdown_grace_period
 
+.. autofunction:: default_context_statistics
+
 Configuring workers
 -------------------
 

--- a/newsfragments/155.feature.rst
+++ b/newsfragments/155.feature.rst
@@ -1,0 +1,2 @@
+Added an API to view statistics about a `WorkerContext`, specifically counting
+``idle_workers`` and ``running_workers``.

--- a/trio_parallel/__init__.py
+++ b/trio_parallel/__init__.py
@@ -7,5 +7,6 @@ from ._impl import (
     WorkerType,
     current_default_worker_limiter,
     atexit_shutdown_grace_period,
+    default_context_statistics,
 )
 from ._abc import BrokenWorkerError

--- a/trio_parallel/_tests/test_defaults.py
+++ b/trio_parallel/_tests/test_defaults.py
@@ -15,6 +15,7 @@ from .._impl import (
     run_sync,
     atexit_shutdown_grace_period,
     open_worker_context,
+    default_context_statistics,
 )
 
 
@@ -200,3 +201,10 @@ def test_change_default_grace_period():
     with pytest.raises(TypeError):
         atexit_shutdown_grace_period(None)
     assert x == atexit_shutdown_grace_period()
+
+
+def test_get_default_context_stats():
+    s = default_context_statistics()
+    assert hasattr(s, "idle_workers")
+    assert hasattr(s, "running_workers")
+    assert s == DEFAULT_CONTEXT.statistics()


### PR DESCRIPTION
Take advantage of `itertools.count` GIL-atomic increments to make threadsafe statistics for the default cache without lock objects. Benchmarking showed locks to have about 50% overhead compared to the previous thread-unsafe implementation, whereas these counters have more like 5% overhead.