### PR TITLE
revamp proc run sync flow

### DIFF
--- a/trio_parallel/_tests/test_proc.py
+++ b/trio_parallel/_tests/test_proc.py
@@ -26,7 +26,7 @@ async def worker(request):
     try:
         yield worker
     finally:
-        with trio.move_on_after(5) as cs:
+        with trio.move_on_after(10) as cs:
             worker.shutdown()
             await worker.wait()
         if cs.cancelled_caught:


### PR DESCRIPTION
reduce the cyclomatic complexity of the main `run_sync` code and improve the readability of pickling (`dumps`) error handling