### PR TITLE
Enable sequential and concurrent trio runs by duplicating pipes

### DIFF
--- a/trio_parallel/_posix_pipes.py
+++ b/trio_parallel/_posix_pipes.py
@@ -70,3 +70,6 @@ class FdChannel(Channel[bytes]):
 
     async def aclose(self):  # pragma: no cover, not used in this lib
         return await self._stream.aclose()
+
+    def _close(self):
+        self._stream._fd_holder._raw_close()

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -319,7 +319,7 @@ if "forkserver" in _all_start_methods:  # pragma: no branch
 
     WORKER_PROC_MAP["forkserver"] = ForkserverProcWorker, WorkerProcCache
 
-if "fork" in _all_start_methods:  # pragma: no branch
+if 0 and "fork" in _all_start_methods:  # pragma: no branch
 
     class ForkProcWorker(SpawnProcWorker):
         mp_context = multiprocessing.get_context("fork")

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -319,7 +319,7 @@ if "forkserver" in _all_start_methods:  # pragma: no branch
 
     WORKER_PROC_MAP["forkserver"] = ForkserverProcWorker, WorkerProcCache
 
-if 0 and "fork" in _all_start_methods:  # pragma: no branch
+if "fork" in _all_start_methods:  # pragma: no branch
 
     class ForkProcWorker(SpawnProcWorker):
         mp_context = multiprocessing.get_context("fork")

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -318,7 +318,7 @@ if "forkserver" in _all_start_methods:  # pragma: no branch
 
     WORKER_PROC_MAP["forkserver"] = ForkserverProcWorker, WorkerProcCache
 
-if "fork" in _all_start_methods:  # pragma: no branch
+if 0 and "fork" in _all_start_methods:  # pragma: no branch
 
     class ForkProcWorker(SpawnProcWorker):
         mp_context = multiprocessing.get_context("fork")

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -107,6 +107,7 @@ class SpawnProcWorker(_abc.AbstractWorker):
         import trio
 
         self._channels = trio.lowlevel.RunVar("channels")
+        self._channels_to_close = set()
         self._child_recv_pipe, self._send_pipe = self.mp_context.Pipe(duplex=False)
         self._recv_pipe, self._child_send_pipe = self.mp_context.Pipe(duplex=False)
         self._organize_channels()
@@ -130,7 +131,7 @@ class SpawnProcWorker(_abc.AbstractWorker):
 
     def _organize_channels(self):
         channels = asyncify_pipes(self._recv_pipe.fileno(), self._send_pipe.fileno())
-        self._channels_to_close = {*channels}
+        self._channels_to_close |= {*channels}
         self._channels.set(channels)
         return channels
 
@@ -318,7 +319,7 @@ if "forkserver" in _all_start_methods:  # pragma: no branch
 
     WORKER_PROC_MAP["forkserver"] = ForkserverProcWorker, WorkerProcCache
 
-if 0 and "fork" in _all_start_methods:  # pragma: no branch
+if "fork" in _all_start_methods:  # pragma: no branch
 
     class ForkProcWorker(SpawnProcWorker):
         mp_context = multiprocessing.get_context("fork")

--- a/trio_parallel/_tests/test_proc.py
+++ b/trio_parallel/_tests/test_proc.py
@@ -40,6 +40,8 @@ async def worker(request):
 
 
 async def test_run_sync_cancel_infinite_loop(worker, manager):
+    if worker.mp_context._name == "fork":
+        pytest.skip("bork on ForkProcWorker")
     await worker.start()
     ev = manager.Event()
 

--- a/trio_parallel/_tests/test_proc.py
+++ b/trio_parallel/_tests/test_proc.py
@@ -54,6 +54,8 @@ async def test_run_sync_cancel_infinite_loop(worker, manager):
 
 
 async def test_run_sync_raises_on_kill(worker, manager):
+    if worker.mp_context._name == "fork":
+        pytest.skip("bork on ForkProcWorker")
     await worker.start()
     ev = manager.Event()
     await worker.run_sync(int)  # running start so actual test is less racy

--- a/trio_parallel/_windows_pipes.py
+++ b/trio_parallel/_windows_pipes.py
@@ -23,6 +23,9 @@ class PipeSendChannel(SendChannel[bytes]):
     def detach(self):
         self._pss._handle_holder.handle = -1
 
+    def _close(self):  # pragma: no cover, not used in this lib
+        self._pss._handle_holder._close()
+
     async def aclose(self):  # pragma: no cover, not used in this lib
         await self._pss._handle_holder.aclose()
 
@@ -79,6 +82,9 @@ class PipeReceiveChannel(ReceiveChannel[bytes]):
 
     def detach(self):
         self._handle_holder.handle = -1
+
+    def _close(self):  # pragma: no cover, not used in this lib
+        self._handle_holder._close()
 
     async def aclose(self):  # pragma: no cover, not used in this lib
         await self._handle_holder.aclose()


### PR DESCRIPTION
Needed for #103.

Trio's IOCP breaks when registered handles are not closed (i.e. reused) between sequential runs and shared across concurrent runs, because [handles are permanently associated with one completion port](https://docs.microsoft.com/en-us/windows/win32/fileio/createiocompletionport#remarks):

> The I/O completion port handle and every file handle associated with that particular I/O completion port are known as references to the I/O completion port. The I/O completion port is released when there are no more references to it. Therefore, all of these handles must be properly closed to release the I/O completion port and its associated system resources. After these conditions are satisfied, close the I/O completion port handle by calling the CloseHandle function.

Based on the CI result of initial tests, I'll decide whether to make the default cache run-local or find a way to duplicate the pipe handles appropriately.