### PR TITLE
Enable sequential and concurrent trio runs by guarding IOCP on Windows

### DIFF
--- a/newsfragments/167.bugfix.rst
+++ b/newsfragments/167.bugfix.rst
@@ -1,2 +1,2 @@
-Fixed a hang that occurred on failed worker subprocess spawns that mostly occurred
-when multiprocessing spawn recursion was not guarded.
+Fixed a hang on failed worker subprocess spawns that mostly occurred upon
+accidental multiprocessing recursive spawn.

--- a/newsfragments/171.bugfix.rst
+++ b/newsfragments/171.bugfix.rst
@@ -1,2 +1,2 @@
-Fixed a hang on Windows when trying to use :mod:`trio_parallel` in sequential and
-concurrent Trio runs.
+Fixed a hang on Windows when trying to use :meth:`WorkerContext.run_sync` in sequential
+and concurrent Trio runs.

--- a/newsfragments/171.bugfix.rst
+++ b/newsfragments/171.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a hang on Windows when trying to use :mod:`trio_parallel` in sequential and
+concurrent Trio runs.

--- a/trio_parallel/_impl.py
+++ b/trio_parallel/_impl.py
@@ -175,11 +175,9 @@ class WorkerContext(metaclass=NoPublicConstructor):
             limiter = current_default_worker_limiter()
 
         try:
-            iocp = trio.lowlevel.current_iocp()
+            worker_cache = self._worker_caches[trio.lowlevel.current_iocp()]
         except AttributeError:
             worker_cache = self._worker_caches[-1]
-        else:
-            worker_cache = self._worker_caches[iocp]
 
         async with limiter, self._lifetime:
             worker_cache.prune()

--- a/trio_parallel/_impl.py
+++ b/trio_parallel/_impl.py
@@ -334,7 +334,7 @@ def graceful_default_shutdown():
     # don't use atexit.register(fn,*args) form
     import time
 
-    deadline = time.perf_counter() - ATEXIT_SHUTDOWN_GRACE_PERIOD
+    deadline = time.perf_counter() + ATEXIT_SHUTDOWN_GRACE_PERIOD
     for cache in DEFAULT_CONTEXT._worker_caches.values():
         cache.shutdown(deadline - time.perf_counter())
         cache.clear()

--- a/trio_parallel/_impl.py
+++ b/trio_parallel/_impl.py
@@ -1,9 +1,9 @@
 import atexit
 import os
-from collections import defaultdict
+import sys
 from enum import Enum
 from itertools import count
-from typing import Type, Callable, Any, Dict
+from typing import Type, Callable, Any
 
 import attr
 from async_generator import asynccontextmanager
@@ -151,7 +151,7 @@ class WorkerContext(metaclass=NoPublicConstructor):
         validator=attr.validators.in_(WorkerType),
     )
     _worker_class: Type[AbstractWorker] = attr.ib(repr=False, init=False)
-    _worker_caches: Dict[int, WorkerCache] = attr.ib(repr=False, init=False)
+    _worker_cache: WorkerCache = attr.ib(repr=False, init=False)
     _lifetime: ContextLifetimeManager = attr.ib(
         factory=ContextLifetimeManager, repr=False, init=False
     )
@@ -159,7 +159,7 @@ class WorkerContext(metaclass=NoPublicConstructor):
     def __attrs_post_init__(self):
         worker_class, cache_class = WORKER_MAP[self.worker_type]
         self.__dict__["_worker_class"] = worker_class
-        self.__dict__["_worker_caches"] = defaultdict(cache_class)
+        self.__dict__["_worker_cache"] = cache_class()
 
     async def run_sync(self, sync_fn, *args, cancellable=False, limiter=None):
         """Run ``sync_fn(*args)`` in a separate process and return/raise it's outcome.
@@ -174,17 +174,12 @@ class WorkerContext(metaclass=NoPublicConstructor):
         if limiter is None:
             limiter = current_default_worker_limiter()
 
-        try:
-            worker_cache = self._worker_caches[trio.lowlevel.current_iocp()]
-        except AttributeError:
-            worker_cache = self._worker_caches[-1]
-
         async with limiter, self._lifetime:
-            worker_cache.prune()
+            self._worker_cache.prune()
             while True:
                 with trio.CancelScope(shield=not cancellable):
                     try:
-                        worker = worker_cache.pop()
+                        worker = self._worker_cache.pop()
                     except IndexError:
                         worker = self._worker_class(
                             self.idle_timeout, self.init, self.retire
@@ -197,29 +192,65 @@ class WorkerContext(metaclass=NoPublicConstructor):
                     # when KI-protected & cancellable=False
                     await trio.lowlevel.checkpoint_if_cancelled()
                 else:
-                    worker_cache.append(worker)
+                    self._worker_cache.append(worker)
                     return result.unwrap()
 
-    async def _aclose(self):
+    async def _aclose(self, grace_period=None):
         import trio
 
+        if grace_period is None:
+            grace_period = self.grace_period
         with trio.CancelScope(shield=True):
             await self._lifetime.close_and_wait()
-            for cache in self._worker_caches.values():
-                await trio.to_thread.run_sync(cache.shutdown, self.grace_period)
+            await trio.to_thread.run_sync(self._worker_cache.shutdown, grace_period)
 
     def statistics(self):
-        idle = 0
-        for cache in self._worker_caches.values():
-            cache.prune()
-            idle += len(cache)
+        self._worker_cache.prune()
         return WorkerContextStatistics(
-            idle_workers=idle,
+            idle_workers=len(self._worker_cache),
             running_workers=self._lifetime.calc_running(),
         )
 
 
-DEFAULT_CONTEXT = WorkerContext._create()  # intentionally skip open_worker_context
+# intentionally skip open_worker_context
+DEFAULT_CONTEXT = WorkerContext._create()
+DEFAULT_CONTEXT_RUNVAR = None
+if sys.platform == "win32":
+
+    async def close_at_run_end(ctx):
+        import trio
+
+        try:
+            await trio.sleep_forever()
+        finally:
+            await ctx._aclose(ATEXIT_SHUTDOWN_GRACE_PERIOD)
+
+    def get_default_context():
+        import trio
+
+        global DEFAULT_CONTEXT_RUNVAR
+
+        if DEFAULT_CONTEXT_RUNVAR is None:
+            DEFAULT_CONTEXT_RUNVAR = trio.lowlevel.RunVar("win32_ctx")
+        try:
+            ctx = DEFAULT_CONTEXT_RUNVAR.get()
+        except LookupError:
+            ctx = WorkerContext._create()
+            DEFAULT_CONTEXT_RUNVAR.set(ctx)
+            trio.lowlevel.spawn_system_task(close_at_run_end, ctx)
+        return ctx
+
+
+else:
+
+    def get_default_context():
+        return DEFAULT_CONTEXT
+
+    @atexit.register
+    def graceful_default_shutdown():
+        # need to late-bind the context attribute lookup so
+        # don't use atexit.register(fn,*args) form
+        DEFAULT_CONTEXT._worker_cache.shutdown(ATEXIT_SHUTDOWN_GRACE_PERIOD)
 
 
 def default_context_statistics():
@@ -233,7 +264,7 @@ def default_context_statistics():
 
        The statistics are only eventually consistent in the case of multiple trio
        threads concurrently using `trio_parallel.run_sync`."""
-    return DEFAULT_CONTEXT.statistics()
+    return get_default_context().statistics()
 
 
 @asynccontextmanager
@@ -320,18 +351,6 @@ def atexit_shutdown_grace_period(grace_period=-1.0):
     return ATEXIT_SHUTDOWN_GRACE_PERIOD
 
 
-@atexit.register
-def graceful_default_shutdown():
-    # need to late-bind the context attribute lookup so
-    # don't use atexit.register(fn,*args) form
-    import time
-
-    deadline = time.perf_counter() + ATEXIT_SHUTDOWN_GRACE_PERIOD
-    for cache in DEFAULT_CONTEXT._worker_caches.values():
-        cache.shutdown(deadline - time.perf_counter())
-        cache.clear()
-
-
 async def run_sync(sync_fn, *args, cancellable=False, limiter=None):
     """Run ``sync_fn(*args)`` in a separate process and return/raise it's outcome.
 
@@ -375,6 +394,6 @@ async def run_sync(sync_fn, *args, cancellable=False, limiter=None):
         in normal use.
 
     """
-    return await DEFAULT_CONTEXT.run_sync(
+    return await get_default_context().run_sync(
         sync_fn, *args, cancellable=cancellable, limiter=limiter
     )

--- a/trio_parallel/_impl.py
+++ b/trio_parallel/_impl.py
@@ -150,11 +150,11 @@ class WorkerContext(metaclass=NoPublicConstructor):
         default=WorkerType.SPAWN,
         validator=attr.validators.in_(WorkerType),
     )
+    _worker_class: Type[AbstractWorker] = attr.ib(repr=False, init=False)
+    _worker_caches: Dict[int, WorkerCache] = attr.ib(repr=False, init=False)
     _lifetime: ContextLifetimeManager = attr.ib(
         factory=ContextLifetimeManager, repr=False, init=False
     )
-    _worker_class: Type[AbstractWorker] = attr.ib(repr=False, init=False)
-    _worker_caches: Dict[int, WorkerCache] = attr.ib(repr=False, init=False)
 
     def __attrs_post_init__(self):
         worker_class, cache_class = WORKER_MAP[self.worker_type]

--- a/trio_parallel/_posix_pipes.py
+++ b/trio_parallel/_posix_pipes.py
@@ -1,11 +1,11 @@
-import os
+import sys
 import struct
 from typing import TYPE_CHECKING
 
 import trio
 from trio.abc import Channel
 
-assert os.name != "nt" or not TYPE_CHECKING
+assert not sys.platform == "win32" or not TYPE_CHECKING
 
 
 # We copy the wire protocol code from multiprocessing.connection.Connection

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -1,4 +1,4 @@
-import os
+import sys
 import multiprocessing
 import time
 
@@ -18,7 +18,7 @@ from . import _abc
 multiprocessing.get_logger()  # to register multiprocessing atexit handler
 ACK = b"0x06"
 
-if os.name == "nt":
+if sys.platform == "win32":
 
     async def wait(obj):
         from trio.lowlevel import WaitForSingleObject

--- a/trio_parallel/_proc.py
+++ b/trio_parallel/_proc.py
@@ -159,11 +159,10 @@ class SpawnProcWorker(_abc.AbstractWorker):
         # between processes. (Trio will take charge via cancellation.)
         signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-        # Signal successful startup.
-        send_pipe.send_bytes(ACK)
-
         try:
             if isinstance(init, bytes):  # true except on "fork"
+                # Signal successful startup to spawn/forkserver parents.
+                send_pipe.send_bytes(ACK)
                 init = loads(init)
             if isinstance(retire, bytes):  # true except on "fork"
                 retire = loads(retire)
@@ -213,14 +212,20 @@ class SpawnProcWorker(_abc.AbstractWorker):
         self._child_send_pipe.close()
         self._child_recv_pipe.close()
 
+        # The following is mainly needed in the case of accidental recursive spawn
         async def wait_then_fail():
             await self.wait()
             raise BrokenWorkerProcessError("Worker failed to start", self.proc)
 
         async with trio.open_nursery() as nursery:
-            nursery.cancel_scope.shield = True
             nursery.start_soon(wait_then_fail)
-            code = await self._receive_chan.receive()
+            try:
+                code = await self._receive_chan.receive()
+            except BaseException:
+                self.kill()
+                with trio.CancelScope(shield=True):
+                    await self.wait()
+                raise
             assert code == ACK
             nursery.cancel_scope.cancel()
 
@@ -335,9 +340,6 @@ if "fork" in _all_start_methods:  # pragma: no branch
             self._child_recv_pipe.close()
             del self._init
             del self._retire
-            with trio.CancelScope(shield=True):
-                code = await self._receive_chan.receive()
-            assert code == ACK
 
     WORKER_PROC_MAP["fork"] = ForkProcWorker, WorkerProcCache
 

--- a/trio_parallel/_tests/test_defaults.py
+++ b/trio_parallel/_tests/test_defaults.py
@@ -231,7 +231,7 @@ def test_get_default_context_stats():
 
 def test_sequential_runs(shutdown_cache):
     async def run_with_timeout():
-        with trio.fail_after(5):
+        with trio.fail_after(10):
             return await run_sync(os.getpid, cancellable=True)
 
     same_pid = trio.run(run_with_timeout) == trio.run(run_with_timeout)

--- a/trio_parallel/_tests/test_impl.py
+++ b/trio_parallel/_tests/test_impl.py
@@ -96,7 +96,6 @@ async def test_context_methods(mock_context):
     )
 
 
-# TODO: get cross-platform prune/shutdown counts
 # TODO: test running workers != 0
 async def test_context_methods2(mock_context):
     async with _impl.open_worker_context() as ctx:
@@ -107,12 +106,12 @@ async def test_context_methods2(mock_context):
         s = ctx.statistics()
         assert s.idle_workers == 1
         assert s.running_workers == 0
-        # assert sum(cache.pruned_count for cache in ctx._worker_caches.values()) == 3
-    # assert sum(cache.shutdown_count for cache in ctx._worker_caches.values()) == 1
+        assert sum(cache.pruned_count for cache in ctx._worker_caches.values()) == 2
+    assert sum(cache.shutdown_count for cache in ctx._worker_caches.values()) == 1
     s = ctx.statistics()
     assert s.idle_workers == 0
     assert s.running_workers == 0
-    # assert sum(cache.pruned_count for cache in ctx._worker_caches.values()) == 4
+    assert sum(cache.pruned_count for cache in ctx._worker_caches.values()) == 3
 
 
 async def test_cancellable(mock_context):

--- a/trio_parallel/_tests/test_impl.py
+++ b/trio_parallel/_tests/test_impl.py
@@ -77,22 +77,22 @@ def mock_context(monkeypatch):
 async def test_context_methods(mock_context):
     await run_sync(bool)
     await run_sync(bool)
-    assert (
-        sum(cache.pruned_count for cache in mock_context._worker_caches.values()) == 2
+    assert 2 == sum(
+        cache.pruned_count for cache in mock_context._worker_caches.values()
     )
-    assert (
-        sum(cache.shutdown_count for cache in mock_context._worker_caches.values()) == 0
+    assert 0 == sum(
+        cache.shutdown_count for cache in mock_context._worker_caches.values()
     )
     await run_sync(bool)
     with trio.CancelScope() as cs:
         cs.cancel()
         await run_sync(bool)
     assert cs.cancelled_caught
-    assert (
-        sum(cache.pruned_count for cache in mock_context._worker_caches.values()) == 3
+    assert 3 == sum(
+        cache.pruned_count for cache in mock_context._worker_caches.values()
     )
-    assert (
-        sum(cache.shutdown_count for cache in mock_context._worker_caches.values()) == 0
+    assert 0 == sum(
+        cache.shutdown_count for cache in mock_context._worker_caches.values()
     )
 
 
@@ -106,12 +106,12 @@ async def test_context_methods2(mock_context):
         s = ctx.statistics()
         assert s.idle_workers == 1
         assert s.running_workers == 0
-        assert sum(cache.pruned_count for cache in ctx._worker_caches.values()) == 2
-    assert sum(cache.shutdown_count for cache in ctx._worker_caches.values()) == 1
+        assert 2 == sum(cache.pruned_count for cache in ctx._worker_caches.values())
+    assert 1 == sum(cache.shutdown_count for cache in ctx._worker_caches.values())
     s = ctx.statistics()
     assert s.idle_workers == 0
     assert s.running_workers == 0
-    assert sum(cache.pruned_count for cache in ctx._worker_caches.values()) == 3
+    assert 3 == sum(cache.pruned_count for cache in ctx._worker_caches.values())
 
 
 async def test_cancellable(mock_context):

--- a/trio_parallel/_tests/test_impl.py
+++ b/trio_parallel/_tests/test_impl.py
@@ -129,18 +129,13 @@ async def test_cache_scope_args(mock_context):
         init=float, retire=int, idle_timeout=33
     ) as ctx:
         await ctx.run_sync(bool)
-        for cache in ctx._worker_caches.values():
-            if cache:
-                worker = cache.pop()
-                assert worker.init is float
-                assert worker.retire is int
-                assert worker.idle_timeout == 33
-                assert not cache
-                break
-        else:  # pragma: no cover
-            assert False
-        for cache in ctx._worker_caches.values():
-            assert not cache
+        _, cache = ctx._worker_caches.popitem()
+        assert not ctx._worker_caches
+        worker = cache.pop()
+        assert not cache
+        assert worker.init is float
+        assert worker.retire is int
+        assert worker.idle_timeout == 33
 
 
 async def test_erroneous_scope_inputs():

--- a/trio_parallel/_tests/test_impl.py
+++ b/trio_parallel/_tests/test_impl.py
@@ -129,12 +129,18 @@ async def test_cache_scope_args(mock_context):
         init=float, retire=int, idle_timeout=33
     ) as ctx:
         await ctx.run_sync(bool)
-        for cache in mock_context._worker_caches.values():
+        for cache in ctx._worker_caches.values():
             if cache:
-                _, worker = cache.popitem()
+                worker = cache.pop()
                 assert worker.init is float
                 assert worker.retire is int
                 assert worker.idle_timeout == 33
+                assert not cache
+                break
+        else:  # pragma: no cover
+            assert False
+        for cache in ctx._worker_caches.values():
+            assert not cache
 
 
 async def test_erroneous_scope_inputs():

--- a/trio_parallel/_tests/test_impl.py
+++ b/trio_parallel/_tests/test_impl.py
@@ -1,5 +1,6 @@
 """ Tests of public API with mocked-out workers ("collaboration" tests)"""
 import warnings
+from collections import defaultdict
 from typing import Callable, Optional
 
 import pytest
@@ -62,8 +63,7 @@ class MockContext(_impl.WorkerContext):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         self.__dict__["_worker_class"] = MockWorker
-        self.__dict__["_cache_class"] = MockCache
-        self.__dict__["_worker_caches"] = {-1: MockCache()}
+        self.__dict__["_worker_caches"] = defaultdict(MockCache)
 
 
 @pytest.fixture

--- a/trio_parallel/_windows_pipes.py
+++ b/trio_parallel/_windows_pipes.py
@@ -1,4 +1,4 @@
-import os
+import sys
 from typing import TYPE_CHECKING
 
 import trio
@@ -7,7 +7,7 @@ from trio._windows_pipes import PipeSendStream, _HandleHolder, DEFAULT_RECEIVE_S
 from trio.abc import SendChannel, ReceiveChannel
 from ._windows_cffi import ErrorCodes, peek_pipe_message_left
 
-assert os.name == "nt" or not TYPE_CHECKING
+assert sys.platform == "win32" or not TYPE_CHECKING
 
 
 class PipeSendChannel(SendChannel[bytes]):


### PR DESCRIPTION
Closes #170 by superseding it, and makes progress toward #103. Addresses the sequential and concurrent trio run bug first shown in #168 by abandoning platform parity on Windows. Initial implementation is... ugly.