### PR TITLE
clean up names/qualnames of objects

### DIFF
--- a/trio_parallel/__init__.py
+++ b/trio_parallel/__init__.py
@@ -10,3 +10,38 @@ from ._impl import (
     default_context_statistics,
 )
 from ._abc import BrokenWorkerError
+
+
+# Vendored from trio._util in v0.20.0 under identical MIT/Apache2 license.
+# Copyright Contributors to the Trio project.
+def fixup_module_metadata(module_name, namespace):
+    seen_ids = set()
+
+    def fix_one(qualname, name, obj):
+        # avoid infinite recursion (relevant when using
+        # typing.Generic, for example)
+        if id(obj) in seen_ids:
+            return
+        seen_ids.add(id(obj))
+
+        mod = getattr(obj, "__module__", None)
+        if mod is not None and mod.startswith("trio_parallel."):
+            obj.__module__ = module_name
+            # Modules, unlike everything else in Python, put fully-qualified
+            # names into their __name__ attribute. Trio checks for "." to avoid
+            # rewriting these, but we don't have any, so it's always true.
+            hasdot = hasattr(obj, "__name__") and "." not in obj.__name__
+            if hasdot:  # pragma: no branch
+                obj.__name__ = name
+                obj.__qualname__ = qualname
+            if isinstance(obj, type):
+                for attr_name, attr_value in obj.__dict__.items():
+                    fix_one(objname + "." + attr_name, attr_name, attr_value)
+
+    for objname, obj in namespace.items():
+        if not objname.startswith("_"):  # ignore private attributes
+            fix_one(objname, objname, obj)
+
+
+fixup_module_metadata(__name__, globals())
+del fixup_module_metadata

--- a/trio_parallel/_abc.py
+++ b/trio_parallel/_abc.py
@@ -84,7 +84,9 @@ class WorkerCache(Deque[AbstractWorker], ABC):
               shutdown signal within ``grace_period``."""
 
 
-# vendored from trio so it's not Final and we can subclass a test fake
+# Vendored from trio._util in v0.19.0 under identical MIT/Apache2 license.
+# Copyright Contributors to the Trio project.
+# Modified so it's not Final so that we can create a test fake subclass.
 T = TypeVar("T")
 
 

--- a/trio_parallel/_tests/test_defaults.py
+++ b/trio_parallel/_tests/test_defaults.py
@@ -257,3 +257,11 @@ async def test_concurrent_runs(shutdown_cache):
     async with trio.open_nursery() as n:
         for i in range(2):
             n.start_soon(trio.to_thread.run_sync, trio.run, worker, i)
+
+
+def test_nice_names():
+    import trio_parallel
+
+    for objname, obj in trio_parallel.__dict__.items():
+        if not objname.startswith("_"):  # ignore private attributes
+            assert "._" not in obj.__module__


### PR DESCRIPTION
Vendors a utility from Trio and also improves licence compliance in other vendored code.