### PR TITLE
publish on CI using twine directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,18 @@ jobs:
         with:
           name: Build
           path: dist
-      - name: Publish to Pypi
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+      - name: Setup python
+        uses: actions/setup-python@v4.2.0
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          python-version: "3.10"
+      - name: Install requirements
+        run: |
+          python -m pip install -U pip
+          python -m pip install twine
+      - name: Check distribution
+        run: twine check dist/*
+      - name: Publish to Pypi
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ name = trio-parallel
 description = CPU parallelism for Trio
 url = https://github.com/richardsheridan/trio-parallel
 long_description = file: README.rst
+long_description_content_type = text/rst
 author = Richard Sheridan
 author_email = richard.sheridan@gmail.com
 license = MIT OR Apache-2.0


### PR DESCRIPTION
The action is... just a docker container that installs twine right off of pypi? let's spare the constant "updates" and just use whatever pip gets us.