### PR TITLE
include pypy-win32 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,8 @@ jobs:
           - '3.10'
           - 'pypy-3.7'
           - 'pypy-3.8'
-        arch: [ x64, x86 ]
+          - 'pypy-3.9'
+        arch: [ x64 ]
         include:
           - os: ubuntu-latest
             python: 'pypy-3.9-nightly'
@@ -132,15 +133,15 @@ jobs:
             python: '3.11-dev'
             arch: x64
             experimental: true
+          - os: windows-latest
+            python: '3.7'
+            arch: x86
+            experimental: false
         exclude:
-          - os: windows-latest
-            python: 'pypy-3.7'
-          - os: windows-latest
-            python: 'pypy-3.8'
-          - os: ubuntu-latest
-            arch: x86
           - os: macos-latest
-            arch: x86
+            python: 'pypy-3.7'
+          - os: macos-latest
+            python: 'pypy-3.9'
     steps:
       - name: Input settings
         run: echo "${{ needs.Build.outputs.settings }}" | base64 -d | tar xz

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -25,9 +25,6 @@ jobs:
         source:
           - 'trio-parallel'
           - '-e .'
-        exclude:
-          - os: windows-latest
-            python: 'pypy-3.8'
     steps:
       - name: Checkout
         if: matrix.source == '-e .'

--- a/_trio_parallel_workers/__init__.py
+++ b/_trio_parallel_workers/__init__.py
@@ -5,9 +5,20 @@ Users still need to make sure their CPU-bound functions also do not pull in such
 packages, but at least we are doing our part."""
 
 import signal
+import sys
 from inspect import iscoroutine
 from pickle import HIGHEST_PROTOCOL
 from time import perf_counter
+
+
+if getattr(sys, "pypy_version_info", (8,)) < (7, 3, 10):
+    # mute rogue pypy debug print statement
+    try:
+        import _winapi
+    except ImportError:
+        pass
+    else:
+        _winapi.print = lambda *args, **kwargs: None
 
 try:
     from cloudpickle import dumps, loads


### PR DESCRIPTION
It seems like this library may have been working on pypy on windows for a while now, except for a weird [bug](https://foss.heptapod.net/pypy/pypy/-/issues/3819) now [resolved](https://foss.heptapod.net/pypy/pypy/-/commit/697e82ec79e63f45cb811d6576f2d82afaf952cc).  This PR just makes it "official"