### PR TITLE
Use tblib lazily to pass tracebacks on user exceptions

### DIFF
--- a/_trio_parallel_workers/_funcs.py
+++ b/_trio_parallel_workers/_funcs.py
@@ -94,8 +94,12 @@ def _no_trio():
     return "trio" not in sys.modules
 
 
+class SpecialError(Exception):
+    pass
+
+
 def _chained_exc():
     try:
         raise ValueError("test1")
     except ValueError as e:
-        raise TypeError("test2") from e
+        raise SpecialError("test2") from e

--- a/trio_parallel/_tests/test_worker.py
+++ b/trio_parallel/_tests/test_worker.py
@@ -7,7 +7,7 @@ import math
 import pytest
 import trio
 
-from _trio_parallel_workers._funcs import _null_async_fn, _chained_exc
+from _trio_parallel_workers._funcs import _null_async_fn, _chained_exc, SpecialError
 from .._impl import WORKER_MAP
 
 
@@ -70,7 +70,7 @@ async def test_clean_exit_on_shutdown(worker, capfd):
 
 async def test_tracebacks(worker):
     await worker.start()
-    with pytest.raises(TypeError, match="test2") as excinfo:
+    with pytest.raises(SpecialError, match="test2") as excinfo:
         (await worker.run_sync(_chained_exc)).unwrap()
     c = excinfo.getrepr().chain
     assert c


### PR DESCRIPTION
Previous strategy only registers things that exist in our minimal worker state for pickling. This strategy does a bit of redundant work on each exception passed back from workers but getting more tracebacks seems worth it.