### PR TITLE
fix regression after trio 0.27.0 with explicit wait_task_rescheduled

### DIFF
--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -28,5 +28,5 @@ sortedcontainers==2.4.0
     # via trio
 tblib==3.0.0
     # via -r requirements\install.in
-trio==0.26.0
+trio==0.27.0
     # via -r requirements\install.in


### PR DESCRIPTION
Ran afoul of a subtle new assertion of behavior in https://github.com/python-trio/trio/pull/3096

This is what happens when you get unnecessarily clever trying to reduce lines of code!