### PR TITLE
bugfix trio util removal

### DIFF
--- a/_trio_parallel_workers/_funcs.py
+++ b/_trio_parallel_workers/_funcs.py
@@ -58,12 +58,6 @@ def _never_halts(ev):  # pragma: no cover, worker will be killed
         pass
 
 
-def _raise_ki():
-    import signal, trio
-
-    trio._util.signal_raise(signal.SIGINT)
-
-
 _lambda = lambda: None  # pragma: no cover, never run
 
 

--- a/trio_parallel/_tests/test_proc.py
+++ b/trio_parallel/_tests/test_proc.py
@@ -6,6 +6,7 @@
 
 import math
 import os
+import signal
 
 import trio
 import pytest
@@ -13,7 +14,6 @@ import pytest
 from _trio_parallel_workers._funcs import (
     _lambda,
     _return_lambda,
-    _raise_ki,
     _never_halts,
     _no_trio,
 )
@@ -97,7 +97,7 @@ async def test_exhaustively_cancel_run_sync(worker, manager):
 
 
 async def test_ki_does_not_propagate(worker):
-    (await worker.run_sync(_raise_ki)).unwrap()
+    (await worker.run_sync(signal.raise_signal, signal.SIGINT)).unwrap()
 
 
 @pytest.mark.parametrize("job", [_lambda, _return_lambda])


### PR DESCRIPTION
See https://github.com/python-trio/trio/pull/3126. Causes a failure in the [test suite](https://github.com/richardsheridan/trio-parallel/actions/runs/11870858830). No user-facing bug!